### PR TITLE
Add support for disabling all background message processing

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,10 +1,10 @@
-name: Run Test Suite on PR or push to master
+name: Run Test Suite on PR or push to main
 
 on:
   push:
-    branches: [ master, addTests ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   test:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,9 +13,10 @@
       "request": "launch",
       "preLaunchTask": "build",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/bin/Debug/net5.0/NVSSMessaging.dll",
+      "program": "${workspaceFolder}/messaging/bin/Debug/net5.0/messaging.dll",
+      "requireExactSource": false,
       "args": [],
-      "cwd": "${workspaceFolder}",
+      "cwd": "${workspaceFolder}/messaging",
       "stopAtEntry": false,
       // Enable launching a web browser when ASP.NET Core starts. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser
       "serverReadyAction": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,7 @@
       "type": "process",
       "args": [
         "build",
-        "${workspaceFolder}/NVSSMessaging.csproj",
+        "${workspaceFolder}/messaging/messaging.csproj",
         "/property:GenerateFullPaths=true",
         "/consoleloggerparameters:NoSummary"
       ],
@@ -19,7 +19,7 @@
       "type": "process",
       "args": [
         "publish",
-        "${workspaceFolder}/NVSSMessaging.csproj",
+        "${workspaceFolder}/messaging/messaging.csproj",
         "/property:GenerateFullPaths=true",
         "/consoleloggerparameters:NoSummary"
       ],
@@ -32,7 +32,7 @@
       "args": [
         "watch",
         "run",
-        "${workspaceFolder}/NVSSMessaging.csproj",
+        "${workspaceFolder}/messaging/messaging.csproj",
         "/property:GenerateFullPaths=true",
         "/consoleloggerparameters:NoSummary"
       ],

--- a/messaging/AppSettings.cs
+++ b/messaging/AppSettings.cs
@@ -2,5 +2,5 @@ using System;
 
 public class AppSettings
 {
-    public Boolean SendACKMessages { get; set; } = false;
+    public Boolean AckAndIJEConversion { get; set; } = false;
 }

--- a/messaging/AppSettings.cs
+++ b/messaging/AppSettings.cs
@@ -1,0 +1,6 @@
+using System;
+
+public class AppSettings
+{
+    public Boolean SendACKMessages { get; set; } = false;
+}

--- a/messaging/Controllers/BundlesController.cs
+++ b/messaging/Controllers/BundlesController.cs
@@ -7,6 +7,7 @@ using messaging.Models;
 using messaging.Services;
 using Hl7.Fhir.Model;
 using VRDR;
+using Microsoft.Extensions.Options;
 
 namespace messaging.Controllers
 {
@@ -16,11 +17,13 @@ namespace messaging.Controllers
     {
         private readonly ApplicationDbContext _context;
         private readonly IServiceProvider Services;
+        private readonly AppSettings _settings;
 
-        public BundlesController(ApplicationDbContext context, IServiceProvider services)
+        public BundlesController(ApplicationDbContext context, IServiceProvider services, IOptions<AppSettings> settings)
         {
             _context = context;
             Services = services;
+            _settings = settings.Value;
         }
 
         // GET: Bundles
@@ -64,7 +67,9 @@ namespace messaging.Controllers
                 _context.IncomingMessageItems.Add(item);
                 _context.SaveChanges();
 
-                queue.QueueConvertToIJE(item.Id);
+                if(_settings.AckAndIJEConversion) {
+                    queue.QueueConvertToIJE(item.Id);
+                }
             } catch {
                 return BadRequest();
             }

--- a/messaging/Program.cs
+++ b/messaging/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using messaging.Services;
+using Microsoft.Extensions.Options;
 
 namespace messaging
 {

--- a/messaging/Services/ConvertToIJEBackgroundWork.cs
+++ b/messaging/Services/ConvertToIJEBackgroundWork.cs
@@ -30,13 +30,11 @@ namespace messaging.Services
       public class Worker : IBackgroundWorker<Message, Worker>
       {
           private readonly ApplicationDbContext _context;
-          private readonly AppSettings _appSettings;
 
-          public Worker(ApplicationDbContext context, IOptions<AppSettings> settings)
+          public Worker(ApplicationDbContext context)
           {
               // This is where you put your dependencies, services, etc.
               this._context = context;
-              this._appSettings = settings.Value;
           }
 
           public async Task DoWork(Message message, CancellationToken cancellationToken)
@@ -108,14 +106,12 @@ namespace messaging.Services
         }
 
         private void CreateAckMessage(BaseMessage message) {
-            if(this._appSettings.SendACKMessages) {
-                OutgoingMessageItem outgoingMessageItem = new OutgoingMessageItem();
-                AckMessage ackMessage = new AckMessage(message);
-                outgoingMessageItem.Message = ackMessage.ToJSON();
-                outgoingMessageItem.MessageId = ackMessage.MessageId;
-                this._context.OutgoingMessageItems.Add(outgoingMessageItem);
-                this._context.SaveChanges();
-            }
+            OutgoingMessageItem outgoingMessageItem = new OutgoingMessageItem();
+            AckMessage ackMessage = new AckMessage(message);
+            outgoingMessageItem.Message = ackMessage.ToJSON();
+            outgoingMessageItem.MessageId = ackMessage.MessageId;
+            this._context.OutgoingMessageItems.Add(outgoingMessageItem);
+            this._context.SaveChanges();
         }
 
         private bool IncomingMessageLogItemExists(string messageId)

--- a/messaging/Startup.cs
+++ b/messaging/Startup.cs
@@ -21,6 +21,7 @@ namespace messaging
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.Configure<AppSettings>(Configuration.GetSection("AppSettings"));
             services.AddMemoryCache();
             services.AddMiniProfiler(options => options.RouteBasePath = "/profiler").AddEntityFramework();
             services.AddDbContext<ApplicationDbContext>(opt =>

--- a/messaging/appsettings.Development.json
+++ b/messaging/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
   "AppSettings": {
-    "SendACKMessages": true
+    "AckAndIJEConversion": true
   },
   "Logging": {
     "LogLevel": {

--- a/messaging/appsettings.Development.json
+++ b/messaging/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "AppSettings": {
+    "SendACKMessages": true
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/messaging/appsettings.Test.json
+++ b/messaging/appsettings.Test.json
@@ -1,4 +1,7 @@
 {
+  "AppSettings": {
+    "SendACKMessages": true
+  },
   "ConnectionStrings": {
     "NVSSMessagingDatabase": "Server=localhost;Database=nvssmessagingtest;User=sa;Password=yourStrong(!)Password;"
   }

--- a/messaging/appsettings.Test.json
+++ b/messaging/appsettings.Test.json
@@ -1,6 +1,6 @@
 {
   "AppSettings": {
-    "SendACKMessages": true
+    "AckAndIJEConversion": true
   },
   "ConnectionStrings": {
     "NVSSMessagingDatabase": "Server=localhost;Database=nvssmessagingtest;User=sa;Password=yourStrong(!)Password;"


### PR DESCRIPTION
By default the application will not do background processing, only when AppSettings.AckAndIJEConversion is set to true in the appropriate AppSettings.json will the app write ACK messages to the OutgoingMessageItems table and convert messages to IJE.

This PR also fixes the `.vscode/launch.json` and `.vscode/tasks.json` since they were never updated when the repo was restructured into `messaging` and `messaging.tests` folders.