### PR TITLE
Store more information about messages in the database outside of the JSON message blob

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ This section documents information useful for developers of the API itself and i
 
 1. Run MSSQL server: In development `docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=yourStrong(!)Password' -p 1433:1433 -d mcr.microsoft.com/mssql/server`, or in production configure a proper MSSQL instance to your organizational requirements.
 2. Ensure the `NVSSMessagingDatabase` contains the proper MSSQL connection string for your environment in `messaging/appsettings.Development.json`
-3. Migrate your local database to match the current migration: `dotnet run --project messaging database update`
+3. Migrate your local database to match the current migration: `dotnet ef --project messaging database update`
 4. Run the server using `dotnet run --project messaging`
 
 ## Deploying in Production

--- a/messaging/Migrations/20211203145846_AddMessageIdentificationInformation.Designer.cs
+++ b/messaging/Migrations/20211203145846_AddMessageIdentificationInformation.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using messaging.Models;
 
 namespace messaging.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20211203145846_AddMessageIdentificationInformation")]
+    partial class AddMessageIdentificationInformation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/messaging/Migrations/20211203145846_AddMessageIdentificationInformation.cs
+++ b/messaging/Migrations/20211203145846_AddMessageIdentificationInformation.cs
@@ -1,0 +1,119 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace messaging.Migrations
+{
+    public partial class AddMessageIdentificationInformation : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "MessageId",
+                table: "OutgoingMessageItems",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Message",
+                table: "OutgoingMessageItems",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "MessageType",
+                table: "OutgoingMessageItems",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "MessageId",
+                table: "IncomingMessageLogs",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "MessageId",
+                table: "IncomingMessageItems",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ProcessedStatus",
+                table: "IncomingMessageItems",
+                type: "CHAR(10)",
+                maxLength: 10,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Source",
+                table: "IncomingMessageItems",
+                type: "CHAR(3)",
+                maxLength: 3,
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MessageType",
+                table: "OutgoingMessageItems");
+
+            migrationBuilder.DropColumn(
+                name: "ProcessedStatus",
+                table: "IncomingMessageItems");
+
+            migrationBuilder.DropColumn(
+                name: "Source",
+                table: "IncomingMessageItems");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "MessageId",
+                table: "OutgoingMessageItems",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Message",
+                table: "OutgoingMessageItems",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "MessageId",
+                table: "IncomingMessageLogs",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "MessageId",
+                table: "IncomingMessageItems",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+        }
+    }
+}

--- a/messaging/Migrations/20211207185123_AddIndexesForNCHSIdAndMessageId.Designer.cs
+++ b/messaging/Migrations/20211207185123_AddIndexesForNCHSIdAndMessageId.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using messaging.Models;
 
 namespace messaging.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20211207185123_AddIndexesForNCHSIdAndMessageId")]
+    partial class AddIndexesForNCHSIdAndMessageId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/messaging/Migrations/20211207185123_AddIndexesForNCHSIdAndMessageId.cs
+++ b/messaging/Migrations/20211207185123_AddIndexesForNCHSIdAndMessageId.cs
@@ -1,0 +1,65 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace messaging.Migrations
+{
+    public partial class AddIndexesForNCHSIdAndMessageId : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "NCHSIdentifier",
+                table: "IncomingMessageLogs",
+                type: "nvarchar(450)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "MessageId",
+                table: "IncomingMessageLogs",
+                type: "nvarchar(450)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IncomingMessageLogs_MessageId",
+                table: "IncomingMessageLogs",
+                column: "MessageId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IncomingMessageLogs_NCHSIdentifier",
+                table: "IncomingMessageLogs",
+                column: "NCHSIdentifier");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_IncomingMessageLogs_MessageId",
+                table: "IncomingMessageLogs");
+
+            migrationBuilder.DropIndex(
+                name: "IX_IncomingMessageLogs_NCHSIdentifier",
+                table: "IncomingMessageLogs");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "NCHSIdentifier",
+                table: "IncomingMessageLogs",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(450)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "MessageId",
+                table: "IncomingMessageLogs",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(450)");
+        }
+    }
+}

--- a/messaging/Migrations/20211209005127_AddIndexToOutgoingMessageItemsCreatedDate.Designer.cs
+++ b/messaging/Migrations/20211209005127_AddIndexToOutgoingMessageItemsCreatedDate.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using messaging.Models;
 
 namespace messaging.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20211209005127_AddIndexToOutgoingMessageItemsCreatedDate")]
+    partial class AddIndexToOutgoingMessageItemsCreatedDate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/messaging/Migrations/20211209005127_AddIndexToOutgoingMessageItemsCreatedDate.cs
+++ b/messaging/Migrations/20211209005127_AddIndexToOutgoingMessageItemsCreatedDate.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace messaging.Migrations
+{
+    public partial class AddIndexToOutgoingMessageItemsCreatedDate : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_OutgoingMessageItems_CreatedDate",
+                table: "OutgoingMessageItems",
+                column: "CreatedDate");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_OutgoingMessageItems_CreatedDate",
+                table: "OutgoingMessageItems");
+        }
+    }
+}

--- a/messaging/Migrations/20211210213447_AddJurisdictionIdToAllTables.Designer.cs
+++ b/messaging/Migrations/20211210213447_AddJurisdictionIdToAllTables.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using messaging.Models;
 
 namespace messaging.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20211210213447_AddJurisdictionIdToAllTables")]
+    partial class AddJurisdictionIdToAllTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/messaging/Migrations/20211210213447_AddJurisdictionIdToAllTables.cs
+++ b/messaging/Migrations/20211210213447_AddJurisdictionIdToAllTables.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace messaging.Migrations
+{
+    public partial class AddJurisdictionIdToAllTables : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "JurisdictionId",
+                table: "OutgoingMessageItems",
+                type: "CHAR(2)",
+                maxLength: 2,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "JurisdictionId",
+                table: "IncomingMessageLogs",
+                type: "CHAR(2)",
+                maxLength: 2,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "JurisdictionId",
+                table: "IncomingMessageItems",
+                type: "CHAR(2)",
+                maxLength: 2,
+                nullable: false,
+                defaultValue: "");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "JurisdictionId",
+                table: "OutgoingMessageItems");
+
+            migrationBuilder.DropColumn(
+                name: "JurisdictionId",
+                table: "IncomingMessageLogs");
+
+            migrationBuilder.DropColumn(
+                name: "JurisdictionId",
+                table: "IncomingMessageItems");
+        }
+    }
+}

--- a/messaging/Models/IncomingMessageItem.cs
+++ b/messaging/Models/IncomingMessageItem.cs
@@ -1,5 +1,7 @@
-using System;
 using System.Text.Json.Serialization;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.ComponentModel;
 
 namespace messaging.Models
 {
@@ -8,6 +10,14 @@ namespace messaging.Models
         public long Id { get; set; }
         [JsonIgnore]
         public string Message { get; set; }
+        [Required]
         public string MessageId { get; set; }
+        [Column(TypeName = "CHAR")]
+        [MaxLength(3)]
+        public string Source { get; set; }
+        [Column(TypeName = "CHAR")]
+        [MaxLength(10)]
+        [Required]
+        public string ProcessedStatus { get; set; } = "QUEUED";
     }
 }

--- a/messaging/Models/IncomingMessageItem.cs
+++ b/messaging/Models/IncomingMessageItem.cs
@@ -1,7 +1,6 @@
 using System.Text.Json.Serialization;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using System.ComponentModel;
 
 namespace messaging.Models
 {

--- a/messaging/Models/IncomingMessageItem.cs
+++ b/messaging/Models/IncomingMessageItem.cs
@@ -18,5 +18,9 @@ namespace messaging.Models
         [MaxLength(10)]
         [Required]
         public string ProcessedStatus { get; set; } = "QUEUED";
+        [Column(TypeName = "CHAR")]
+        [MaxLength(2)]
+        [Required]
+        public string JurisdictionId { get; set; } = "MA";
     }
 }

--- a/messaging/Models/IncomingMessageLog.cs
+++ b/messaging/Models/IncomingMessageLog.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace messaging.Models
 {
@@ -14,5 +15,9 @@ namespace messaging.Models
         public string NCHSIdentifier { get; set; }
         public string StateAuxiliaryIdentifier { get; set; }
         public DateTimeOffset? MessageTimestamp { get; set; }
+        [Column(TypeName = "CHAR")]
+        [MaxLength(2)]
+        [Required]
+        public string JurisdictionId { get; set; }
     }
 }

--- a/messaging/Models/IncomingMessageLog.cs
+++ b/messaging/Models/IncomingMessageLog.cs
@@ -1,8 +1,11 @@
 using System;
+using Microsoft.EntityFrameworkCore;
 using System.ComponentModel.DataAnnotations;
 
 namespace messaging.Models
 {
+    [Index(nameof(MessageId))]
+    [Index(nameof(NCHSIdentifier))]
     public class IncomingMessageLog : BaseEntity
     {
         public long Id { get; set; }

--- a/messaging/Models/IncomingMessageLog.cs
+++ b/messaging/Models/IncomingMessageLog.cs
@@ -1,10 +1,12 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace messaging.Models
 {
     public class IncomingMessageLog : BaseEntity
     {
         public long Id { get; set; }
+        [Required]
         public string MessageId { get; set; }
         public string NCHSIdentifier { get; set; }
         public string StateAuxiliaryIdentifier { get; set; }

--- a/messaging/Models/OutgoingMessageItem.cs
+++ b/messaging/Models/OutgoingMessageItem.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
 
 namespace messaging.Models
 {
+    [Index(nameof(CreatedDate))]
     public class OutgoingMessageItem : BaseEntity
     {
         public long Id { get; set; }

--- a/messaging/Models/OutgoingMessageItem.cs
+++ b/messaging/Models/OutgoingMessageItem.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 
 namespace messaging.Models
@@ -13,5 +14,9 @@ namespace messaging.Models
         public string MessageType { get; set; }
         [Required]
         public string MessageId { get; set; }
+        [Column(TypeName = "CHAR")]
+        [MaxLength(2)]
+        [Required]
+        public string JurisdictionId { get; set; }
     }
 }

--- a/messaging/Models/OutgoingMessageItem.cs
+++ b/messaging/Models/OutgoingMessageItem.cs
@@ -1,12 +1,15 @@
-using System;
-using System.Text.Json.Serialization;
+using System.ComponentModel.DataAnnotations;
 
 namespace messaging.Models
 {
     public class OutgoingMessageItem : BaseEntity
     {
         public long Id { get; set; }
+        [Required]
         public string Message { get; set; }
+        [Required]
+        public string MessageType { get; set; }
+        [Required]
         public string MessageId { get; set; }
     }
 }

--- a/messaging/Services/ConvertToIJEBackgroundWork.cs
+++ b/messaging/Services/ConvertToIJEBackgroundWork.cs
@@ -39,6 +39,8 @@ namespace messaging.Services
           public async Task DoWork(Message message, CancellationToken cancellationToken)
         {
             IncomingMessageItem item = this._context.IncomingMessageItems.Find(message.Id);
+            item.ProcessedStatus = "PROCESSED";
+            this._context.Update(item);
             BaseMessage parsedMessage = BaseMessage.Parse(item.Message.ToString(), true);
             IJEItem ijeItem = new IJEItem();
             OutgoingMessageItem outgoingMessageItem = new OutgoingMessageItem();

--- a/messaging/Services/ConvertToIJEBackgroundWork.cs
+++ b/messaging/Services/ConvertToIJEBackgroundWork.cs
@@ -1,5 +1,4 @@
 using messaging.Models;
-using Microsoft.Extensions.Options;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -110,6 +109,7 @@ namespace messaging.Services
             AckMessage ackMessage = new AckMessage(message);
             outgoingMessageItem.Message = ackMessage.ToJSON();
             outgoingMessageItem.MessageId = ackMessage.MessageId;
+            outgoingMessageItem.MessageType = ackMessage.GetType().Name;
             this._context.OutgoingMessageItems.Add(outgoingMessageItem);
             this._context.SaveChanges();
         }

--- a/messaging/Services/ConvertToIJEBackgroundWork.cs
+++ b/messaging/Services/ConvertToIJEBackgroundWork.cs
@@ -81,7 +81,7 @@ namespace messaging.Services
             ijeItem.IJE = new IJEMortality(message.DeathRecord).ToString();
             CreateAckMessage(message);
             bool duplicateMessage = IncomingMessageLogItemExists(message.MessageId);
-            IncomingMessageLog previousMessage = LatestMessageByNCHSAndStateId(message.NCHSIdentifier, message.StateAuxiliaryIdentifier);
+            IncomingMessageLog previousMessage = LatestMessageByNCHSId(message.NCHSIdentifier);
             if(!duplicateMessage) {
                 // Only log messages that are not duplicates
                 LogMessage(message);
@@ -119,9 +119,9 @@ namespace messaging.Services
             return this._context.IncomingMessageLogs.Any(l => l.MessageId == messageId);
         }
 
-        private IncomingMessageLog LatestMessageByNCHSAndStateId(string NCHSIdentifier, string stateId)
+        private IncomingMessageLog LatestMessageByNCHSId(string NCHSIdentifier)
         {
-            return this._context.IncomingMessageLogs.Where(l => l.NCHSIdentifier == NCHSIdentifier && l.StateAuxiliaryIdentifier == stateId).OrderBy(l => l.MessageTimestamp).LastOrDefault();
+            return this._context.IncomingMessageLogs.Where(l => l.NCHSIdentifier == NCHSIdentifier).OrderBy(l => l.MessageTimestamp).LastOrDefault();
         }
 
         private bool IncomingMessageItemExists(long id)


### PR DESCRIPTION
IncomingMessageItems table schema changes:
* Rename the FileSource column to Source (this will differentiate direct messages from jurisdictions from those using STEVE)
* Add a ProcessedStatus column (when NVSS API inserts the FHIR messages into the IncomingMessage table the ProcessingStatus column will be set to “QUEUED”; when the NCHS API PARSER parses the FHIR Message, it will set that column to “PROCESSED”)

OutgoingMessageItems table schema changes:
* Add a MessageType column (value is based on result of message.GetType().Name)
