### PR TITLE
Update db to store meta data

### DIFF
--- a/messaging/Controllers/BundlesController.cs
+++ b/messaging/Controllers/BundlesController.cs
@@ -71,6 +71,9 @@ namespace messaging.Controllers
                 item.MessageId = message.MessageId;
                 item.MessageType = message.GetType().Name;
                 item.JurisdictionId = jurisdictionId;
+                item.EventYear = message.DeathYear;
+                item.CertificateNumber = message.CertificateNumber;
+                item.EventType = getEventType(message);
                 _context.IncomingMessageItems.Add(item);
                 _context.SaveChanges();
 
@@ -83,6 +86,39 @@ namespace messaging.Controllers
 
             // return HTTP status code 204 (No Content)
             return NoContent();
+        }
+
+        // getEventType generates an EventType string "MOR", "NAT", or "FET"
+        // for debugging and tracking records in the db
+        // For now we only have "MOR" records but we could add "NAT" and "FET" here later
+        private string getEventType(BaseMessage message)
+        {
+            switch (message.MessageType)
+            {
+                case "http://nchs.cdc.gov/vrdr_submission":
+                    return "MOR";
+                    break;
+                case "http://nchs.cdc.gov/vrdr_submission_update":
+                    return "MOR";
+                    break;
+                case "http://nchs.cdc.gov/vrdr_acknowledgement":
+                    return "MOR";
+                    break;
+                case "http://nchs.cdc.gov/vrdr_submission_void":
+                    return "MOR";
+                    break;
+                case "http://nchs.cdc.gov/vrdr_coding":
+                    return "MOR";
+                    break;
+                case "http://nchs.cdc.gov/vrdr_coding_update":
+                    return "MOR";
+                    break;
+                case "http://nchs.cdc.gov/vrdr_extraction_error":
+                    return "MOR";
+                    break;
+                default:
+                    return "UNK";
+            }
         }
     }
 }

--- a/messaging/Migrations/20220203213326_Add-Meta-Data-Columns.Designer.cs
+++ b/messaging/Migrations/20220203213326_Add-Meta-Data-Columns.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using messaging.Models;
 
@@ -11,9 +12,10 @@ using messaging.Models;
 namespace messaging.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220203213326_Add-Meta-Data-Columns")]
+    partial class AddMetaDataColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/messaging/Migrations/20220203213326_Add-Meta-Data-Columns.cs
+++ b/messaging/Migrations/20220203213326_Add-Meta-Data-Columns.cs
@@ -1,0 +1,75 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace messaging.Migrations
+{
+    public partial class AddMetaDataColumns : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "CertificateNumber",
+                table: "OutgoingMessageItems",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "EventType",
+                table: "OutgoingMessageItems",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "EventYear",
+                table: "OutgoingMessageItems",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "CertificateNumber",
+                table: "IncomingMessageItems",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "EventType",
+                table: "IncomingMessageItems",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "EventYear",
+                table: "IncomingMessageItems",
+                type: "bigint",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CertificateNumber",
+                table: "OutgoingMessageItems");
+
+            migrationBuilder.DropColumn(
+                name: "EventType",
+                table: "OutgoingMessageItems");
+
+            migrationBuilder.DropColumn(
+                name: "EventYear",
+                table: "OutgoingMessageItems");
+
+            migrationBuilder.DropColumn(
+                name: "CertificateNumber",
+                table: "IncomingMessageItems");
+
+            migrationBuilder.DropColumn(
+                name: "EventType",
+                table: "IncomingMessageItems");
+
+            migrationBuilder.DropColumn(
+                name: "EventYear",
+                table: "IncomingMessageItems");
+        }
+    }
+}

--- a/messaging/Models/IncomingMessageItem.cs
+++ b/messaging/Models/IncomingMessageItem.cs
@@ -25,5 +25,8 @@ namespace messaging.Models
         [MaxLength(2)]
         [Required]
         public string JurisdictionId { get; set; }
+        public uint? EventYear { get; set;}
+        public uint? CertificateNumber {get; set;}
+        public string EventType {get; set;}
     }
 }

--- a/messaging/Models/OutgoingMessageItem.cs
+++ b/messaging/Models/OutgoingMessageItem.cs
@@ -18,5 +18,8 @@ namespace messaging.Models
         [MaxLength(2)]
         [Required]
         public string JurisdictionId { get; set; }
+        public uint? EventYear { get; set;}
+        public uint? CertificateNumber {get; set;}
+        public string EventType {get; set;}
     }
 }


### PR DESCRIPTION
Veronique's request:

- For the IncomingMessageItems table
  - event year
  - certificate number
  - Event type --  values could be “ MOR” – represents death Record”, “FET “ represents Fetal Death”, “NAT” – represents Natality. 
- For OutgoingMessageItems table
  - event year
  - certificate number
  -  Event type --  values could be either “ MOR” – represents death Record”, “FET “ represents Fetal Death”, “NAT” – represents Natality.