### PR TITLE
356 v1.3 updates, add RetrievedAt column

### DIFF
--- a/messaging.tests/Integration/BundlesControllerTests.cs
+++ b/messaging.tests/Integration/BundlesControllerTests.cs
@@ -41,7 +41,7 @@ namespace messaging.tests
       var baseBundle = await JsonResponseHelpers.ParseBundleAsync(bundles);
 
       // Create a new empty Death Record
-      DeathRecordSubmission recordSubmission = new DeathRecordSubmission(new DeathRecord());
+      DeathRecordSubmissionMessage recordSubmission = new DeathRecordSubmissionMessage(new DeathRecord());
 
       // Submit that Death Record
       HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/MA/Bundles", recordSubmission.ToJson());
@@ -69,7 +69,7 @@ namespace messaging.tests
 
       // Extract the message from the bundle and ensure it is an ACK for the appropritae message
       var lastMessageInBundle = updatedBundle.Entry.Last();
-      AckMessage parsedMessage = BaseMessage.Parse<AckMessage>((Hl7.Fhir.Model.Bundle)lastMessageInBundle.Resource);
+      AcknowledgementMessage parsedMessage = BaseMessage.Parse<AcknowledgementMessage>((Hl7.Fhir.Model.Bundle)lastMessageInBundle.Resource);
       Assert.Equal(recordSubmission.MessageId, parsedMessage.AckedMessageId);
     }
 
@@ -91,7 +91,7 @@ namespace messaging.tests
       var ijeItems = _context.IJEItems.Count();
 
       // Create a new empty Death Record
-      DeathRecordSubmission recordSubmission = new DeathRecordSubmission(new DeathRecord());
+      DeathRecordSubmissionMessage recordSubmission = new DeathRecordSubmissionMessage(new DeathRecord());
 
       // Submit that Death Record
       HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/MA/Bundles", recordSubmission.ToJson());
@@ -127,13 +127,13 @@ namespace messaging.tests
       var ijeItems = _context.IJEItems.Count();
 
       // Create a new empty Death Record
-      DeathRecordSubmission recordSubmission = new DeathRecordSubmission(new DeathRecord());
+      DeathRecordSubmissionMessage recordSubmission = new DeathRecordSubmissionMessage(new DeathRecord());
 
       // Submit that Death Record
       HttpResponseMessage submissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/MA/Bundles", recordSubmission.ToJson());
       Assert.Equal(HttpStatusCode.NoContent, submissionMessage.StatusCode);
 
-      DeathRecordUpdate recordUpdate = new DeathRecordUpdate(recordSubmission.DeathRecord);
+      DeathRecordUpdateMessage recordUpdate = new DeathRecordUpdateMessage(recordSubmission.DeathRecord);
 
       // Submit update message
       HttpResponseMessage updateMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/MA/Bundles", recordUpdate.ToJson());

--- a/messaging/Controllers/BundlesController.cs
+++ b/messaging/Controllers/BundlesController.cs
@@ -73,13 +73,14 @@ namespace messaging.Controllers
                 item.MessageType = message.GetType().Name;
                 item.JurisdictionId = jurisdictionId;
                 item.EventYear = message.DeathYear;
-                if (message.CertificateNumber == null)
+
+                if (message.CertNo == null)
                 {
                     item.CertificateNumber = null;
                 }
                 else
                 {
-                    uint certNo = (uint)message.CertificateNumber;
+                    uint certNo = (uint)message.CertNo;
                     string certNoFmt = certNo.ToString("D6");
                     item.CertificateNumber = certNoFmt;
                 }
@@ -90,7 +91,7 @@ namespace messaging.Controllers
                 if(_settings.AckAndIJEConversion) {
                     queue.QueueConvertToIJE(item.Id);
                 }
-            } catch (Exception ex){
+            } catch {
                 return BadRequest();
             }
 
@@ -113,7 +114,6 @@ namespace messaging.Controllers
                 case "http://nchs.cdc.gov/vrdr_coding_update":
                 case "http://nchs.cdc.gov/vrdr_extraction_error":
                     return "MOR";
-                    break;
                 default:
                     return "UNK";
             }

--- a/messaging/Controllers/BundlesController.cs
+++ b/messaging/Controllers/BundlesController.cs
@@ -33,36 +33,37 @@ namespace messaging.Controllers
         {
             // TODO only allow the since param in development
             // if _since is the default value, then apply the retrieved at logic
+            List<OutgoingMessageItem> outgoingMessages = new List<OutgoingMessageItem>();
             IEnumerable<System.Threading.Tasks.Task<VRDR.BaseMessage>> messageTasks;
             if (_since == default(DateTime))
             {
-                // Determine if the ToList and Select could lead to duplication if the result is iterated more than once
-                // get all messages that have not yet been retrieved 
-                messageTasks = _context.OutgoingMessageItems.Where(message => message.RetrievedAt == null && message.JurisdictionId == jurisdictionId).ToList()
-                                                            .Select(message => System.Threading.Tasks.Task.Run(() => BaseMessage.Parse(message.Message, true))); 
+                // This uses the general FHIR parser and then sees if the json is a Bundle of BaseMessage Type
+                // this will improve performance and prevent vague failures on the server, clients will be responsible for identifying incorrect messages
+                outgoingMessages = _context.OutgoingMessageItems.Where(message => message.RetrievedAt == null && message.JurisdictionId == jurisdictionId).ToList();
+                messageTasks = outgoingMessages.Select(message => System.Threading.Tasks.Task.Run(() => BaseMessage.ParseGenericMessage(message.Message, true))); 
             }
             else
             {
-                // Determine if the ToList and Select could lead to duplication if the result is iterated more than once
-                messageTasks = _context.OutgoingMessageItems.Where(message => message.CreatedDate >= _since && message.JurisdictionId == jurisdictionId).ToList()
-                                                            .Select(message => System.Threading.Tasks.Task.Run(() => BaseMessage.Parse(message.Message, true)));            
+                outgoingMessages = _context.OutgoingMessageItems.Where(message => message.CreatedDate >= _since && message.JurisdictionId == jurisdictionId).ToList();
+                messageTasks = outgoingMessages.Select(message => System.Threading.Tasks.Task.Run(() => BaseMessage.ParseGenericMessage(message.Message, true)));            
             }
+
+            // create bundle to hold the response
             Bundle responseBundle = new Bundle();
             responseBundle.Type = Bundle.BundleType.Searchset;
             responseBundle.Timestamp = DateTime.Now;
             var messages = await System.Threading.Tasks.Task.WhenAll(messageTasks);
             DateTime retrievedTime = DateTime.UtcNow;
+            
+            // Add messages to the bundle
             foreach (var message in messages)
             {
                 responseBundle.AddResourceEntry((Bundle)message, "urn:uuid:" + message.MessageId);
-                // update each outgoing message's RetrievedAt field
-
-                // TODO see if we could keep the reference to the message item selected above so we can make the update there
-                // and avoid another query here
-                OutgoingMessageItem msgItem = _context.OutgoingMessageItems.Where(msg => msg.MessageId == message.MessageId).First();
-                msgItem.RetrievedAt = retrievedTime;
-                _context.SaveChanges();
             }
+
+            // update each outgoing message's RetrievedAt field
+            outgoingMessages.ForEach(msgItem => msgItem.RetrievedAt = retrievedTime);
+            _context.SaveChanges();
             return responseBundle;
         }
 

--- a/messaging/Migrations/20220518194636_Add-RetrievedAt-Column.Designer.cs
+++ b/messaging/Migrations/20220518194636_Add-RetrievedAt-Column.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using messaging.Models;
 
@@ -11,9 +12,10 @@ using messaging.Models;
 namespace messaging.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220518194636_Add-RetrievedAt-Column")]
+    partial class AddRetrievedAtColumn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -177,7 +179,7 @@ namespace messaging.Migrations
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
-                    b.Property<DateTime?>("RetrievedAt")
+                    b.Property<DateTime>("RetrievedAt")
                         .HasColumnType("datetime2");
 
                     b.Property<DateTime>("UpdatedDate")

--- a/messaging/Migrations/20220518194636_Add-RetrievedAt-Column.cs
+++ b/messaging/Migrations/20220518194636_Add-RetrievedAt-Column.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace messaging.Migrations
+{
+    public partial class AddRetrievedAtColumn : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "RetrievedAt",
+                table: "OutgoingMessageItems",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RetrievedAt",
+                table: "OutgoingMessageItems");
+        }
+    }
+}

--- a/messaging/Migrations/20220518195409_Make-RetrievedAt-Nullable.Designer.cs
+++ b/messaging/Migrations/20220518195409_Make-RetrievedAt-Nullable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using messaging.Models;
 
@@ -11,9 +12,10 @@ using messaging.Models;
 namespace messaging.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220518195409_Make-RetrievedAt-Nullable")]
+    partial class MakeRetrievedAtNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/messaging/Migrations/20220518195409_Make-RetrievedAt-Nullable.cs
+++ b/messaging/Migrations/20220518195409_Make-RetrievedAt-Nullable.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace messaging.Migrations
+{
+    public partial class MakeRetrievedAtNullable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "RetrievedAt",
+                table: "OutgoingMessageItems",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "RetrievedAt",
+                table: "OutgoingMessageItems",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+        }
+    }
+}

--- a/messaging/Models/OutgoingMessageItem.cs
+++ b/messaging/Models/OutgoingMessageItem.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
@@ -25,5 +26,7 @@ namespace messaging.Models
         [Column(TypeName = "CHAR")]
         [MaxLength(3)]
         public string EventType {get; set;}
+
+        public DateTime? RetrievedAt { get; set; }
     }
 }

--- a/messaging/Services/ConvertToIJEBackgroundWork.cs
+++ b/messaging/Services/ConvertToIJEBackgroundWork.cs
@@ -1,4 +1,5 @@
 using messaging.Models;
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -46,22 +47,24 @@ namespace messaging.Services
             outgoingMessageItem.JurisdictionId = item.JurisdictionId;
             try {
                 switch(parsedMessage) {
-                    case DeathRecordUpdate update:
+                    case DeathRecordUpdateMessage update:
                         HandleUpdateMessage(update, item);
                     break;
-                    case DeathRecordSubmission submission:
+                    case DeathRecordSubmissionMessage submission:
                         HandleSubmissionMessage(submission, item);
                     break;
                 }
             } catch {
                 ExtractionErrorMessage errorMessage = new ExtractionErrorMessage(parsedMessage);
                 outgoingMessageItem.Message = errorMessage.ToJSON();
+                outgoingMessageItem.MessageId = errorMessage.MessageId;
+                outgoingMessageItem.MessageType = errorMessage.GetType().Name;
                 this._context.OutgoingMessageItems.Add(outgoingMessageItem);
             }
             await this._context.SaveChangesAsync();
           }
 
-        private void HandleSubmissionMessage(DeathRecordSubmission message, IncomingMessageItem databaseMessage) {
+        private void HandleSubmissionMessage(DeathRecordSubmissionMessage message, IncomingMessageItem databaseMessage) {
             IJEItem ijeItem = new IJEItem();
             ijeItem.MessageId = message.MessageId;
             ijeItem.IJE = new IJEMortality(message.DeathRecord).ToString();
@@ -77,7 +80,7 @@ namespace messaging.Services
             }
         }
 
-        private void HandleUpdateMessage(DeathRecordUpdate message, IncomingMessageItem databaseMessage) {
+        private void HandleUpdateMessage(DeathRecordUpdateMessage message, IncomingMessageItem databaseMessage) {
             IJEItem ijeItem = new IJEItem();
             ijeItem.MessageId = message.MessageId;
             ijeItem.IJE = new IJEMortality(message.DeathRecord).ToString();
@@ -96,20 +99,20 @@ namespace messaging.Services
             }
         }
 
-        private void LogMessage(DeathRecordSubmission message, IncomingMessageItem databaseMessage) {
+        private void LogMessage(DeathRecordSubmissionMessage message, IncomingMessageItem databaseMessage) {
             IncomingMessageLog entry = new IncomingMessageLog();
             entry.MessageTimestamp = message.MessageTimestamp;
             entry.MessageId = message.MessageId;
             entry.JurisdictionId = databaseMessage.JurisdictionId;
             entry.NCHSIdentifier = message.NCHSIdentifier;
-            entry.StateAuxiliaryIdentifier = message.StateAuxiliaryIdentifier;
+            entry.StateAuxiliaryIdentifier = message.StateAuxiliaryId;
             this._context.IncomingMessageLogs.Add(entry);
             this._context.SaveChanges();
         }
 
         private void CreateAckMessage(BaseMessage message, IncomingMessageItem databaseMessage) {
             OutgoingMessageItem outgoingMessageItem = new OutgoingMessageItem();
-            AckMessage ackMessage = new AckMessage(message);
+            AcknowledgementMessage ackMessage = new AcknowledgementMessage(message);
             outgoingMessageItem.JurisdictionId = databaseMessage.JurisdictionId;
             outgoingMessageItem.Message = ackMessage.ToJSON();
             outgoingMessageItem.MessageId = ackMessage.MessageId;

--- a/messaging/messaging.csproj
+++ b/messaging/messaging.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="MiniProfiler.AspNetCore.Mvc" Version="4.2.22"/>
     <PackageReference Include="MiniProfiler.EntityFrameworkCore" Version="4.2.22"/>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3"/>
-    <PackageReference Include="VRDR.Messaging" Version="3.2.1"/>
+    <PackageReference Include="VRDR.Messaging" Version="4.0.0-preview2" />
     <!-- <ProjectReference Include="..\..\vrdr-dotnet\VRDR\DeathRecord.csproj" />
     <ProjectReference Include="..\..\vrdr-dotnet\VRDR.Messaging\VRDRMessaging.csproj" /> -->
     <!-- Uncomment the following line if you want to write logging to a file (also uncomment accompanying line in the Startup.cs) -->


### PR DESCRIPTION
Updated the FHIR API to use the latest version of the library running in master
Added a RetrievedAt column to the outgoing messages table
Expected behavior defined in ticket [NVSS-325](https://tracker.codev.mitre.org/browse/NVSS-325)

- If the _since parameter is specified in the GET request, return all outgoing messages for the jurisdiction since the provided timestamp
- If the _since parameter is not provided, return all outgoing messages for the jurisdiction where RetrievedAt == null
- The RetrievedAt timestamp is updated for all messages returned in the GET request response

NOTE This PR does not include the changes to support the STEVE endpoints. This is the first iteration to test the RetrievedAt functionality and will be expanded in a future PR to support the STEVE endpoints.