### PR TITLE
Configure serilog to write to file, use appsettings config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ jmeter.log
 appsettings.json
 .vs
 **.csproj.user
+messaging/logs

--- a/README.md
+++ b/README.md
@@ -302,18 +302,53 @@ This section documents information useful for developers of the API itself and i
 5. Run the server using `dotnet run --project messaging`
 
 ## Logging
+The application uses Serilog as the third party log provider. Serilog can be configured in the appsettings.json file. 
+
+### Logging Sinks
+Serilog supports a variety of sinks to write your logs to. The default configuration writes the logs to the console and to a file. A new file is created each day and files are deleted after 31 days by default. These default configurations can be overwritten in the appsettings.json file. Serilog's provided sinks are listed [here](https://github.com/serilog/serilog/wiki/Provided-Sinks). Splunk, S3, and DBs are among the many options provided by serilog. To change the sink configuration, update the "Using" and "WriteTo" configuration fields in the example below.
+```
+  "Serilog": {
+    "Using": [
+      "Serilog.Sinks.ApplicationInsights", "Serilog.Sinks.File"
+    ],
+    "WriteTo": [
+      { "Name": "Console" },
+      { "Name": "File", "Args": { "path": "Logs/log.txt", "rollingInterval": "Day"} }
+    ],
+    ...
+  }
+```
+### Turn Off Logging
+To turn off logging to a sink, remove the `WriteTo` configuration for the sink you wish to remove. Ex. below will only write to the console.
+```
+  "Serilog": {
+    "Using": [
+      "Serilog.Sinks.ApplicationInsights"
+    ],
+    "WriteTo": [
+      { "Name": "Console" }
+    ],
+    ...
+  }
+```
 
 ### Debug Logging
 To turn on debug logging, update the log level from `Information` to `Debug` in appsettings.json, see example below
 ```
-  "Logging": {
-    "LogLevel": {
+  "Serilog": {
+    ...
+    "MinimumLevel": {
       "Default": "Debug",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Debug",
-      "Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware": "Debug"
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information",
+        "System": "Information",
+        "Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware": "Debug"
+      }
     }
+  },
 ```
+
 
 ### Logging to File
 To save logs to a file, uncomment the line below in Startup.cs

--- a/messaging/Startup.cs
+++ b/messaging/Startup.cs
@@ -59,10 +59,6 @@ namespace messaging
             {
                 endpoints.MapControllers();
             });
-
-            // Uncomment the following line to enable logging when running under IIS
-            // Serilog.Extensions.Logging.File must also be enabled in messaging.csproj
-            // loggerFactory.AddFile("logs/nvssmessaging-{Date}.txt");
         }
     }
 }

--- a/messaging/appsettings.json.sample
+++ b/messaging/appsettings.json.sample
@@ -1,9 +1,20 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+  "Serilog": {
+    "Using": [
+      "Serilog.Sinks.ApplicationInsights", "Serilog.Sinks.File"
+    ],
+    "WriteTo": [
+      { "Name": "Console" },
+      { "Name": "File", "Args": { "path": "Logs/log.txt", "rollingInterval": "Day"} }
+    ],
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information",
+        "System": "Information",
+        "Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware": "Debug"
+      }
     }
   },
   "AllowedHosts": "*",

--- a/messaging/messaging.csproj
+++ b/messaging/messaging.csproj
@@ -14,7 +14,10 @@
     <PackageReference Include="MiniProfiler.EntityFrameworkCore" Version="4.2.22"/>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3"/>
     <PackageReference Include="VRDR.Messaging" Version="4.0.0-preview4" />
-    <!-- Uncomment the following line if you want to write logging to a file (also uncomment accompanying line in the Startup.cs) -->
-    <!-- <PackageReference Include="Serilog.Extensions.Logging.File" Version="2.0.0"/> -->
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.1-dev-00337" />
+    <PackageReference Include="Serilog.AspNetCore" Version="6.0.0-dev-00265" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.1-dev-00038" />
+
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Set up serilog to read from the appsettings config file and to be injected into the rest of the application so we can use more of its features. The appsettings sample file has been updated to show an example of what the new settings should look like. All instances of the app will need to have the appsettings updated. 

Now, file logging and debug logging can be turned on and off from the appsettings json file. The sink can also be configured in the future to write to something other than a file. The list of serilog sinks are at the link below. They include services like splunk, so if CDC uses something like that for production apps, we should just have to update the configuration.

https://github.com/serilog/serilog/wiki/Provided-Sinks