### PR TITLE
Add alias to message types

### DIFF
--- a/messaging/Controllers/BundlesController.cs
+++ b/messaging/Controllers/BundlesController.cs
@@ -334,14 +334,17 @@ namespace messaging.Controllers
         {
             switch (message.MessageType)
             {
+                case "http://nchs.cdc.gov/vrdr_acknowledgement":
+                case "http://nchs.cdc.gov/vrdr_alias":
+                case "http://nchs.cdc.gov/vrdr_causeofdeath_coding":
+                case "http://nchs.cdc.gov/vrdr_causeofdeath_coding_update":
+                case "http://nchs.cdc.gov/vrdr_demographics_coding":
+                case "http://nchs.cdc.gov/vrdr_demographics_coding_update":
+                case "http://nchs.cdc.gov/vrdr_extraction_error":
+                case "http://nchs.cdc.gov/vrdr_status":
                 case "http://nchs.cdc.gov/vrdr_submission":
                 case "http://nchs.cdc.gov/vrdr_submission_update":
-                case "http://nchs.cdc.gov/vrdr_acknowledgement":
                 case "http://nchs.cdc.gov/vrdr_submission_void":
-                case "http://nchs.cdc.gov/vrdr_coding":
-                case "http://nchs.cdc.gov/vrdr_coding_update":
-                case "http://nchs.cdc.gov/vrdr_extraction_error":
-                case "http://nchs.cdc.gov/vrdr_alias":
                     return "MOR";
                 default:
                     return "UNK";

--- a/messaging/Controllers/BundlesController.cs
+++ b/messaging/Controllers/BundlesController.cs
@@ -341,6 +341,7 @@ namespace messaging.Controllers
                 case "http://nchs.cdc.gov/vrdr_coding":
                 case "http://nchs.cdc.gov/vrdr_coding_update":
                 case "http://nchs.cdc.gov/vrdr_extraction_error":
+                case "http://nchs.cdc.gov/vrdr_alias":
                     return "MOR";
                 default:
                     return "UNK";


### PR DESCRIPTION
Add missing message types to the bundles controller so they are labeled as "MOR" in the database