### PR TITLE
Fill in missing source endpoint

### DIFF
--- a/messaging.tests/Integration/SteveEndpointTests.cs
+++ b/messaging.tests/Integration/SteveEndpointTests.cs
@@ -42,6 +42,10 @@ namespace messaging.tests
 
             // Create and submit a new empty Death Record
             DeathRecordSubmissionMessage recordSubmission = new DeathRecordSubmissionMessage(new DeathRecord());
+            
+            // Set missing required fields
+            recordSubmission.MessageSource = "http://example.fhir.org";
+
             HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, STEVE_ENDPOINT, recordSubmission.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, createSubmissionMessage.StatusCode);
 
@@ -74,6 +78,9 @@ namespace messaging.tests
 
             // Create a new empty Death Record
             DeathRecordSubmissionMessage recordSubmission = new DeathRecordSubmissionMessage(new DeathRecord());
+            
+            // Set missing required fields
+            recordSubmission.MessageSource = "http://example.fhir.org";
 
             // Submit that Death Record
             HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, STEVE_ENDPOINT, recordSubmission.ToJson());
@@ -104,10 +111,17 @@ namespace messaging.tests
 
             // Create and submit a new empty Death Record
             DeathRecordSubmissionMessage recordSubmission = new DeathRecordSubmissionMessage(new DeathRecord());
+            
+            // Set missing required fields
+            recordSubmission.MessageSource = "http://example.fhir.org";
+            
             HttpResponseMessage submissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, STEVE_ENDPOINT, recordSubmission.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, submissionMessage.StatusCode);
 
             DeathRecordUpdateMessage recordUpdate = new DeathRecordUpdateMessage(recordSubmission.DeathRecord);
+            
+            // Set missing required fields
+            recordUpdate.MessageSource = "http://example.fhir.org";
 
             // Submit update message
             HttpResponseMessage updateMessage = await JsonResponseHelpers.PostJsonAsync(_client, STEVE_ENDPOINT, recordUpdate.ToJson());
@@ -133,6 +147,10 @@ namespace messaging.tests
 
             // Create and submit a new empty Death Record
             DeathRecordSubmissionMessage recordSubmission = new DeathRecordSubmissionMessage(new DeathRecord());
+
+            // Set missing required fields
+            recordSubmission.MessageSource = "http://example.fhir.org";
+
             HttpResponseMessage submissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, STEVE_ENDPOINT, recordSubmission.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, submissionMessage.StatusCode);
 

--- a/messaging/Controllers/BundlesController.cs
+++ b/messaging/Controllers/BundlesController.cs
@@ -264,24 +264,15 @@ namespace messaging.Controllers
                         _logger.LogDebug($"A message parsing exception occurred while parsing the incoming message: {ex}");
                         return BadRequest($"Failed to parse message: {ex.Message}. Please verify that it is consistent with the current Vital Records Messaging FHIR Implementation Guide.");
                     }
+                    catch (ArgumentException aEx)
+                    {
+                        _logger.LogDebug($"Rejecting message with missing required field: {aEx}");
+                        return BadRequest($"Message was missing required field: {aEx}");
+                    }
                     catch (Exception ex)
                     {
                         _logger.LogDebug($"An exception occurred while parsing the incoming message: {ex}");
                         return BadRequest("Failed to parse message. Please verify that it is consistent with the current Vital Records Messaging FHIR Implementation Guide.");
-                    }
-
-                    // Pre-check some minimal requirements for validity. Specifically, if there are problems with the message that will lead to failure when
-                    // attempting to insert into the database (e.g. missing MessageId), catch that here to return a 400 instead of a 500 on DB error
-                    // Message errors SHOULD result in an ExtractionError response; this check is just to catch things that can't make it that far
-                    if (item.MessageId == null)
-                    {
-                        _logger.LogDebug("Rejecting message with no MessageId");
-                        return BadRequest("Message was missing required field MessageId");
-                    }
-                    if (item.MessageType == null)
-                    {
-                        _logger.LogDebug("Rejecting message with no MessageType.");
-                        return BadRequest("Message was missing required field MessageType");
                     }
 
                     item.Source = GetMessageSource();
@@ -328,32 +319,20 @@ namespace messaging.Controllers
                 entry.Response.Outcome = OperationOutcome.ForMessage($"Failed to parse message: {ex.Message}. Please verify that it is consistent with the current Vital Records Messaging FHIR Implementation Guide.", OperationOutcome.IssueType.Exception);
                 return entry;
             }
+            catch (ArgumentException aEx)
+            {
+                _logger.LogDebug($"An exception occurred while parsing the incoming message: {aEx}");
+                entry.Response = new Bundle.ResponseComponent();
+                entry.Response.Status = "400";
+                entry.Response.Outcome = OperationOutcome.ForMessage($"Message was missing required field. {aEx}.", OperationOutcome.IssueType.Exception);
+                return entry;
+            }
             catch (Exception ex)
             {
                 _logger.LogDebug($"An exception occurred while parsing the incoming message: {ex}");
                 entry.Response = new Bundle.ResponseComponent();
                 entry.Response.Status = "400";
                 entry.Response.Outcome = OperationOutcome.ForMessage("Failed to parse message. Please verify that it is consistent with the current Vital Records Messaging FHIR Implementation Guide.", OperationOutcome.IssueType.Exception);
-                return entry;
-            }
-
-            // Pre-check some minimal requirements for validity. Specifically, if there are problems with the message that will lead to failure when
-            // attempting to insert into the database (e.g. missing MessageId), catch that here to return a 400 instead of a 500 on DB error
-            // Message errors SHOULD result in an ExtractionError response; this check is just to catch things that can't make it that far
-            if (item.MessageId == null)
-            {
-                _logger.LogDebug("Rejecting message with no MessageId");
-                entry.Response = new Bundle.ResponseComponent();
-                entry.Response.Status = "400";
-                entry.Response.Outcome = OperationOutcome.ForMessage("Message was missing required field MessageId", OperationOutcome.IssueType.Exception);
-                return entry;
-            }
-            if (item.MessageType == null)
-            {
-                _logger.LogDebug("Rejecting message with no MessageType.");
-                entry.Response = new Bundle.ResponseComponent();
-                entry.Response.Status = "400";
-                entry.Response.Outcome = OperationOutcome.ForMessage("Message was missing required field MessageType", OperationOutcome.IssueType.Exception);
                 return entry;
             }
 
@@ -397,11 +376,31 @@ namespace messaging.Controllers
         protected IncomingMessageItem ParseIncomingMessageItem(string jurisdictionId, object text)
         {
             BaseMessage message = BaseMessage.Parse(text.ToString());
+
+            // Pre-check some minimal requirements for validity. Specifically, if there are problems with the message that will lead to failure when
+            // attempting to insert into the database (e.g. missing MessageId), catch that here to return a 400 instead of a 500 on DB error
+            // Message errors SHOULD result in an ExtractionError response; this check is just to catch things that can't make it that far
             if (String.IsNullOrWhiteSpace(message.MessageSource))
             {
-                _logger.LogDebug($"Message is missing source endpoint, setting the endpoint: {VRDR.MortalityData.Instance.JurisdictionEndpoints[jurisdictionId]}");
-                message.MessageSource = VRDR.MortalityData.Instance.JurisdictionEndpoints[jurisdictionId];
+                _logger.LogDebug($"Message is missing source endpoint, throw exception");
+                throw new ArgumentException("Message source endpoint cannot be null");
             }
+            if (String.IsNullOrWhiteSpace(message.MessageDestination))
+            {
+                _logger.LogDebug($"Message is missing destination endpoint, throw exception");
+                throw new ArgumentException("Message destination endpoint cannot be null");
+            }
+            if (String.IsNullOrWhiteSpace(message.MessageId))
+            {
+                _logger.LogDebug($"Message is missing Message ID, throw exception");
+                throw new ArgumentException("Message ID cannot be null");
+            }
+            if (String.IsNullOrWhiteSpace(message.GetType().Name))
+            {
+                _logger.LogDebug($"Message is missing Message Event Type, throw exception");
+                throw new ArgumentException("Message Event Type cannot be null");
+            }
+
             IncomingMessageItem item = new IncomingMessageItem();
             item.Message = message.ToJSON(); 
             item.MessageId = message.MessageId;

--- a/messaging/Controllers/BundlesController.cs
+++ b/messaging/Controllers/BundlesController.cs
@@ -356,6 +356,7 @@ namespace messaging.Controllers
                 entry.Response.Outcome = OperationOutcome.ForMessage("Message was missing required field MessageType", OperationOutcome.IssueType.Exception);
                 return entry;
             }
+
             item.Source = GetMessageSource();
             try
             {
@@ -396,8 +397,13 @@ namespace messaging.Controllers
         protected IncomingMessageItem ParseIncomingMessageItem(string jurisdictionId, object text)
         {
             BaseMessage message = BaseMessage.Parse(text.ToString());
+            if (String.IsNullOrWhiteSpace(message.MessageSource))
+            {
+                _logger.LogDebug($"Message is missing source endpoint, setting the endpoint: {VRDR.MortalityData.Instance.JurisdictionEndpoints[jurisdictionId]}");
+                message.MessageSource = VRDR.MortalityData.Instance.JurisdictionEndpoints[jurisdictionId];
+            }
             IncomingMessageItem item = new IncomingMessageItem();
-            item.Message = text.ToString();
+            item.Message = message.ToJSON(); 
             item.MessageId = message.MessageId;
             item.MessageType = message.GetType().Name;
             item.JurisdictionId = jurisdictionId;


### PR DESCRIPTION
Sets the source endpoint if it is missing from the submitted message. This will prevent extraction errors. Since the jurisdiction had to authenticate and can only submit to their endpoint, this is not a security risk to set the endpoint for them from a look up table.

~This PR is dependent on branch 471 getting merged into the vrdr-dotnet library so it can look up the endpoint by jurisdiction ID.~
The PR in the library was deleted, changing approach to return an error when source endpoint is missing