### PR TITLE
Improve /Bundle endpoint GET speeds.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ appsettings.json
 .vs
 **.csproj.user
 messaging/logs
+.DS_store

--- a/messaging/Controllers/SteveController.cs
+++ b/messaging/Controllers/SteveController.cs
@@ -19,7 +19,7 @@ namespace messaging.Controllers
 
         public SteveController(ILogger<BundlesController> logger, ApplicationDbContext context, IServiceProvider services, IOptions<AppSettings> settings) : base(logger, context, services, settings) { }
 
-        protected override IEnumerable<OutgoingMessageItem> ExcludeRetrieved(IEnumerable<OutgoingMessageItem> source)
+        protected override IQueryable<OutgoingMessageItem> ExcludeRetrieved(IQueryable<OutgoingMessageItem> source)
         {
             return source.Where(message => message.SteveRetrievedAt == null);
         }


### PR DESCRIPTION
This PR improves speeds on the /Bundle GET endpoint with many records in the database. Previously, 100k records would take ~10 seconds, now 100k records take <0.5 seconds.

This was achieved by use `IQueryable` objects rather than `IEnumerables`.