### PR TITLE
NVSS 484 - Validate Jurisdiction ID in message and URL param.

### DIFF
--- a/APIValidationChecks.md
+++ b/APIValidationChecks.md
@@ -9,6 +9,7 @@ Validation for the following URL parameters: `jurisdictionId` `_count` `page` `_
 | Error Response Code | parameter | Validation Check | Error Message |
 |-----|:------:|----------------|--------|
 | 400 | `jurisdictionId` | `if !VRDR.MortalityData.Instance.JurisdictionCodes.ContainsKey(jurisdictionId)` | bad request: Invalid jurisdiction ID |
+| 400 | `jurisdictionId` | `if !messageJurisdictionId.Equals(urlParamJurisdictionId)` | Message jurisdiction ID {message.JurisdictionId} must match the URL parameter jurisdiction ID {jurisdictionId}. |
 | 400 | `_count` | `if _count < 0` | bad request: _count must not be negative |
 | 400 | `page` | `if page < 1` | bad request: page must not be negative |
 | 400 | `_since` | `if (_since == default(DateTime) && page > 1)` | bad request: Pagination does not support specifying a page without a _since parameter |
@@ -16,14 +17,6 @@ Validation for the following URL parameters: `jurisdictionId` `_count` `page` `_
    
 # POST Requests
 Minimal validation is done on the bundle to avoid complexity at the API level. However, we want to make sure the message is parsable and traceable if it will be added to the database for ITB. It must be parsable, have the required headers, and be a valid event type.
-
-## Parameter Validation
-
-Validation for the following URL parameters: `jurisdictionId`
-
-| Error Response Code | parameter | Validation Check | Error Message |
-|-----|:------:|----------------|--------|
-| 400 | `jurisdictionId` | `if !VRDR.MortalityData.Instance.JurisdictionCodes.ContainsKey(jurisdictionId)` | bad request: Invalid jurisdiction ID |
 
 ## Parsing Validation
 

--- a/messaging.tests/Integration/BundlesControllerTests.cs
+++ b/messaging.tests/Integration/BundlesControllerTests.cs
@@ -44,15 +44,15 @@ namespace messaging.tests
             // Clear any messages in the database for a clean test
             DatabaseHelper.ResetDatabase(_context);
 
-            // Create a new empty Death Record
-            DeathRecordSubmissionMessage recordSubmission = new DeathRecordSubmissionMessage(new DeathRecord());
+            // Create a new Death Record
+            DeathRecordSubmissionMessage recordSubmission = BaseMessage.Parse<DeathRecordSubmissionMessage>(FixtureStream("fixtures/json/DeathRecordSubmissionMessage.json"));
 
             // Set missing required fields
             recordSubmission.MessageSource = "http://example.fhir.org";
             recordSubmission.CertNo = 1;
 
             // Submit that Death Record
-            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/MA/Bundle", recordSubmission.ToJson());
+            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/NY/Bundle", recordSubmission.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, createSubmissionMessage.StatusCode);
 
             Hl7.Fhir.Model.Bundle updatedBundle = null;
@@ -60,7 +60,7 @@ namespace messaging.tests
             // be done is checking to see if the response is correct and if it is still
             // incorrect after the specified delay then assuming that something is wrong
             for (int x = 0; x < 5; ++x) {
-                HttpResponseMessage oneAck = await _client.GetAsync("/MA/Bundle");
+                HttpResponseMessage oneAck = await _client.GetAsync("/NY/Bundle");
                 updatedBundle = await JsonResponseHelpers.ParseBundleAsync(oneAck);
                 if (updatedBundle.Entry.Count > 0) {
                     break;
@@ -71,13 +71,13 @@ namespace messaging.tests
             // with the new retrievedAt column, only one message should be returned
             Assert.Single(updatedBundle.Entry);
 
-            // Check to see if the results returned for a jurisdiction other than MA does not return MA entries
+            // Check to see if the results returned for a jurisdiction other than NY does not return NY entries
             HttpResponseMessage noMessages = await _client.GetAsync("/FL/Bundle");
             var noMessagesBundle = await JsonResponseHelpers.ParseBundleAsync(noMessages);
             Assert.Empty(noMessagesBundle.Entry);
 
             // Check that the retrievedAt column filters out the ACK message if we place another request
-            HttpResponseMessage noNewMsgs = await _client.GetAsync("/MA/Bundle");
+            HttpResponseMessage noNewMsgs = await _client.GetAsync("/NY/Bundle");
             Hl7.Fhir.Model.Bundle emptyBundle = await JsonResponseHelpers.ParseBundleAsync(noNewMsgs);
             Assert.Empty(emptyBundle.Entry);
 
@@ -102,25 +102,25 @@ namespace messaging.tests
             // Clear any messages in the database for a clean test
             DatabaseHelper.ResetDatabase(_context);
 
-            // Create a new empty Death Record
-            DeathRecordSubmissionMessage recordSubmission = new DeathRecordSubmissionMessage(new DeathRecord());
+            // Create a new Death Record
+            DeathRecordSubmissionMessage recordSubmission = BaseMessage.Parse<DeathRecordSubmissionMessage>(FixtureStream("fixtures/json/DeathRecordSubmissionMessage.json"));
 
             // Set missing required fields
             recordSubmission.MessageSource = "http://example.fhir.org";
             recordSubmission.CertNo = 1;
 
             // Submit that Death Record
-            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/MA/Bundle", recordSubmission.ToJson());
+            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/NY/Bundle", recordSubmission.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, createSubmissionMessage.StatusCode);
 
             // Submit Identifical Death Record Again
-            HttpResponseMessage duplicateSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/MA/Bundle", recordSubmission.ToJson());
+            HttpResponseMessage duplicateSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/NY/Bundle", recordSubmission.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, duplicateSubmissionMessage.StatusCode);
 
             // Make sure the ACKs made it into the queue before querying the endpoint
             Assert.Equal(2, await GetTableCount(_context.OutgoingMessageItems, 2));
 
-            HttpResponseMessage oneAck = await _client.GetAsync("/MA/Bundle");
+            HttpResponseMessage oneAck = await _client.GetAsync("/NY/Bundle");
             Hl7.Fhir.Model.Bundle updatedBundle = await JsonResponseHelpers.ParseBundleAsync(oneAck);
 
             // Even though the message is a duplicate, it is still ACK'd
@@ -138,15 +138,15 @@ namespace messaging.tests
 
             // Get the current time
             DateTime currentTime = DateTime.UtcNow;
-            // Create a new empty Death Record
-            DeathRecordSubmissionMessage recordSubmission = new DeathRecordSubmissionMessage(new DeathRecord());
+            // Create a new Death Record
+            DeathRecordSubmissionMessage recordSubmission = BaseMessage.Parse<DeathRecordSubmissionMessage>(FixtureStream("fixtures/json/DeathRecordSubmissionMessage.json"));
 
             // Set missing required fields
             recordSubmission.MessageSource = "http://example.fhir.org";
             recordSubmission.CertNo = 1;
 
             // Submit that Death Record
-            HttpResponseMessage submissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/MA/Bundle", recordSubmission.ToJson());
+            HttpResponseMessage submissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/NY/Bundle", recordSubmission.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, submissionMessage.StatusCode);
 
             DeathRecordUpdateMessage recordUpdate = new DeathRecordUpdateMessage(recordSubmission.DeathRecord);
@@ -156,7 +156,7 @@ namespace messaging.tests
             recordUpdate.CertNo = 1;
 
             // Submit update message
-            HttpResponseMessage updateMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/MA/Bundle", recordUpdate.ToJson());
+            HttpResponseMessage updateMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/NY/Bundle", recordUpdate.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, updateMessage.StatusCode);
 
             // Make sure the ACKs made it into the queue before querying the endpoint
@@ -169,7 +169,7 @@ namespace messaging.tests
             // use the since parameter to make sure we get both messages
             string since = currentTime.ToString("yyyy-MM-ddTHH:mm:ss.fffffff");
             for (int x = 0; x < 3; ++x) {
-                HttpResponseMessage getBundle = await _client.GetAsync("/MA/Bundle?_since=" + since);
+                HttpResponseMessage getBundle = await _client.GetAsync("/NY/Bundle?_since=" + since);
                 updatedBundle = await JsonResponseHelpers.ParseBundleAsync(getBundle);
                 // Waiting for 2 messages to appear
                 if (updatedBundle.Entry.Count > 1) {
@@ -357,7 +357,7 @@ namespace messaging.tests
           }
 
           string batchJson = batchMsg.ToJson();
-          HttpResponseMessage submissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/MA/Bundle", batchJson);
+          HttpResponseMessage submissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/NY/Bundle", batchJson);
           Assert.Equal(HttpStatusCode.OK, submissionMessage.StatusCode);
           Assert.Equal(50, await GetTableCount(_context.IncomingMessageItems, 50));
 
@@ -368,7 +368,7 @@ namespace messaging.tests
           // "next" link should only appear if there are more results
 
           // 1st response verify is 20 records
-          HttpResponseMessage getBundles1 = await JsonResponseHelpers.GetAsync(_client, "/MA/Bundle?_count=20");
+          HttpResponseMessage getBundles1 = await JsonResponseHelpers.GetAsync(_client, "/NY/Bundle?_count=20");
           Assert.Equal(HttpStatusCode.OK, getBundles1.StatusCode);
 
           FhirJsonParser parser = new FhirJsonParser();
@@ -379,7 +379,7 @@ namespace messaging.tests
           Assert.NotNull(bundle1.NextLink);
 
           // 2nd response is 20 records
-          HttpResponseMessage getBundles2 = await JsonResponseHelpers.GetAsync(_client, "/MA/Bundle?_count=20");
+          HttpResponseMessage getBundles2 = await JsonResponseHelpers.GetAsync(_client, "/NY/Bundle?_count=20");
           Assert.Equal(HttpStatusCode.OK, getBundles2.StatusCode);
 
           string bundleOfBundles2 = await getBundles2.Content.ReadAsStringAsync();
@@ -389,7 +389,7 @@ namespace messaging.tests
           Assert.NotNull(bundle2.NextLink);
 
           // 3rd response is 10 records
-          HttpResponseMessage getBundles3 = await JsonResponseHelpers.GetAsync(_client, "/MA/Bundle?_count=20");
+          HttpResponseMessage getBundles3 = await JsonResponseHelpers.GetAsync(_client, "/NY/Bundle?_count=20");
           Assert.Equal(HttpStatusCode.OK, getBundles3.StatusCode);
 
           string bundleOfBundles3 = await getBundles3.Content.ReadAsStringAsync();
@@ -399,7 +399,7 @@ namespace messaging.tests
           Assert.Null(bundle3.NextLink);
 
           // 4th response is 0 records
-          HttpResponseMessage getBundles4 = await JsonResponseHelpers.GetAsync(_client, "/MA/Bundle?_count=20");
+          HttpResponseMessage getBundles4 = await JsonResponseHelpers.GetAsync(_client, "/NY/Bundle?_count=20");
           Assert.Equal(HttpStatusCode.OK, getBundles4.StatusCode);
 
           string bundleOfBundles4 = await getBundles4.Content.ReadAsStringAsync();
@@ -430,7 +430,7 @@ namespace messaging.tests
           }
 
           string batchJson = batchMsg.ToJson();
-          HttpResponseMessage submissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/MA/Bundle", batchJson);
+          HttpResponseMessage submissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/NY/Bundle", batchJson);
           Assert.Equal(HttpStatusCode.OK, submissionMessage.StatusCode);
           Assert.Equal(18, await GetTableCount(_context.IncomingMessageItems, 18));
 
@@ -439,7 +439,7 @@ namespace messaging.tests
 
           // the page count should be set to 5
           // 1st response verify is 5 records
-          HttpResponseMessage getBundles = await JsonResponseHelpers.GetAsync(_client, "/MA/Bundle?_since=" + startTestFmt + "&_count=5");
+          HttpResponseMessage getBundles = await JsonResponseHelpers.GetAsync(_client, "/NY/Bundle?_since=" + startTestFmt + "&_count=5");
           Assert.Equal(HttpStatusCode.OK, getBundles.StatusCode);
 
           FhirJsonParser parser = new FhirJsonParser();
@@ -449,7 +449,7 @@ namespace messaging.tests
 
           // the page count should be set to 5
           // 3rd page should only have 3
-          HttpResponseMessage getBundles2 = await JsonResponseHelpers.GetAsync(_client, "/MA/Bundle?_since=" + startTestFmt + "&_count=5&page=4");
+          HttpResponseMessage getBundles2 = await JsonResponseHelpers.GetAsync(_client, "/NY/Bundle?_since=" + startTestFmt + "&_count=5&page=4");
           Assert.Equal(HttpStatusCode.OK, getBundles2.StatusCode);
 
           string bundleOfBundles2 = await getBundles2.Content.ReadAsStringAsync();
@@ -547,13 +547,13 @@ namespace messaging.tests
             // Clear any messages in the database for a clean test
             DatabaseHelper.ResetDatabase(_context);
 
-            // Create a new empty Death Record WITH nchs in the endpoint list
-            DeathRecordSubmissionMessage recordSubmission = new DeathRecordSubmissionMessage(new DeathRecord());
+            // Create a new Death Record WITH nchs in the endpoint list
+            DeathRecordSubmissionMessage recordSubmission = BaseMessage.Parse<DeathRecordSubmissionMessage>(FixtureStream("fixtures/json/DeathRecordSubmissionMessage.json"));
             recordSubmission.MessageSource = "http://example.fhir.org";
             recordSubmission.CertNo = 1;
             recordSubmission.MessageDestination = "http://notnchs.cdc.gov/vrdr_submission,http://nchs.cdc.gov/vrdr_submission";
             // Submit that Death Record
-            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, $"/MA/Bundle", recordSubmission.ToJson());
+            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, $"/NY/Bundle", recordSubmission.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, createSubmissionMessage.StatusCode);
         }
 
@@ -631,6 +631,38 @@ namespace messaging.tests
 
             HttpResponseMessage response = await _client.GetAsync($"/{badJurisdiction}/Bundle");
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        [Fact]
+        public async void PostWithNonMatchingJurisdictionsError()
+        {
+            // Clear any messages in the database for a clean test
+            DatabaseHelper.ResetDatabase(_context);
+
+            // The jurisdiction ID of the input record submission is 'NY', which should not work with a 'PA' endpoint parameter.
+            string jurisdictionParameter = "PA";
+
+            // Create a new Death Record
+            DeathRecordSubmissionMessage recordSubmission = BaseMessage.Parse<DeathRecordSubmissionMessage>(FixtureStream("fixtures/json/DeathRecordSubmissionMessage.json"));
+
+            // Submit that Death Record
+            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, $"/{jurisdictionParameter}/Bundle", recordSubmission.ToJson());
+            Assert.Equal(HttpStatusCode.BadRequest, createSubmissionMessage.StatusCode);
+        }
+
+        [Fact]
+        public async void PostBatchWithNonMatchingJurisdictionsError()
+        {
+            // Clear any messages in the database for a clean test
+            DatabaseHelper.ResetDatabase(_context);
+
+            // The jurisdiction ID of the input record submission is 'MA', which should not work with a 'PA' endpoint parameter.
+            string jurisdictionParameter = "PA";
+
+            // Create a new batch message
+            string batchJson = FixtureStream("fixtures/json/BatchMessages.json").ReadToEnd();
+            HttpResponseMessage submissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, $"/{jurisdictionParameter}/Bundles", batchJson);
+            Assert.Equal(HttpStatusCode.BadRequest, submissionMessage.StatusCode);
         }
 
         private StreamReader FixtureStream(string filePath)

--- a/messaging.tests/Integration/BundlesControllerTests.cs
+++ b/messaging.tests/Integration/BundlesControllerTests.cs
@@ -662,7 +662,10 @@ namespace messaging.tests
             // Create a new batch message
             string batchJson = FixtureStream("fixtures/json/BatchMessages.json").ReadToEnd();
             HttpResponseMessage submissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, $"/{jurisdictionParameter}/Bundles", batchJson);
-            Assert.Equal(HttpStatusCode.BadRequest, submissionMessage.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, submissionMessage.StatusCode);
+            Bundle responseBundle = await JsonResponseHelpers.ParseBundleAsync(submissionMessage);
+            Assert.Equal("400", responseBundle.Entry[0].Response.Status);
+            Assert.Equal("400", responseBundle.Entry[1].Response.Status);
         }
 
         private StreamReader FixtureStream(string filePath)

--- a/messaging.tests/Integration/SteveEndpointTests.cs
+++ b/messaging.tests/Integration/SteveEndpointTests.cs
@@ -261,7 +261,10 @@ namespace messaging.tests
             // Create a new batch message
             string batchJson = FixtureStream("fixtures/json/BatchMessages.json").ReadToEnd();
             HttpResponseMessage submissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, $"/STEVE/{jurisdictionParameter}/Bundles", batchJson);
-            Assert.Equal(HttpStatusCode.BadRequest, submissionMessage.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, submissionMessage.StatusCode);
+            Hl7.Fhir.Model.Bundle responseBundle = await JsonResponseHelpers.ParseBundleAsync(submissionMessage);
+            Assert.Equal("400", responseBundle.Entry[0].Response.Status);
+            Assert.Equal("400", responseBundle.Entry[1].Response.Status);
         }
 
         private StreamReader FixtureStream(string filePath)

--- a/messaging.tests/Integration/SteveEndpointTests.cs
+++ b/messaging.tests/Integration/SteveEndpointTests.cs
@@ -2,6 +2,7 @@ using messaging.Models;
 using messaging.tests.Helpers;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -19,8 +20,8 @@ namespace messaging.tests
 
         private readonly ApplicationDbContext _context;
 
-        private readonly string STEVE_ENDPOINT = "/STEVE/MA/Bundle";
-        private readonly string MA_ENDPOINT = "/MA/Bundle";
+        private readonly string STEVE_ENDPOINT = "/STEVE/NY/Bundle";
+        private readonly string NY_ENDPOINT = "/NY/Bundle";
 
         public SteveEndpointTests(CustomWebApplicationFactory<messaging.Startup> factory)
         {
@@ -41,7 +42,7 @@ namespace messaging.tests
             DatabaseHelper.ResetDatabase(_context);
 
             // Create and submit a new empty Death Record
-            DeathRecordSubmissionMessage recordSubmission = new DeathRecordSubmissionMessage(new DeathRecord());
+            DeathRecordSubmissionMessage recordSubmission = BaseMessage.Parse<DeathRecordSubmissionMessage>(FixtureStream("fixtures/json/DeathRecordSubmissionMessage.json"));
             
             // Set missing required fields
             recordSubmission.MessageSource = "http://example.fhir.org";
@@ -56,7 +57,7 @@ namespace messaging.tests
             Hl7.Fhir.Model.Bundle updatedBundle = await GetQueuedMessages(STEVE_ENDPOINT);
             Assert.Single(updatedBundle.Entry);
 
-            // Check to see if the results returned for a jurisdiction other than MA does not return MA entries
+            // Check to see if the results returned for a jurisdiction other than NY does not return NY entries
             HttpResponseMessage noMessages = await _client.GetAsync("STEVE/FL/Bundle");
             var noMessagesBundle = await JsonResponseHelpers.ParseBundleAsync(noMessages);
             Assert.Empty(noMessagesBundle.Entry);
@@ -81,7 +82,7 @@ namespace messaging.tests
             DatabaseHelper.ResetDatabase(_context);
 
             // Create a new empty Death Record
-            DeathRecordSubmissionMessage recordSubmission = new DeathRecordSubmissionMessage(new DeathRecord());
+            DeathRecordSubmissionMessage recordSubmission = BaseMessage.Parse<DeathRecordSubmissionMessage>(FixtureStream("fixtures/json/DeathRecordSubmissionMessage.json"));
             
             // Set missing required fields
             recordSubmission.MessageSource = "http://example.fhir.org";
@@ -115,7 +116,7 @@ namespace messaging.tests
             DatabaseHelper.ResetDatabase(_context);
 
             // Create and submit a new empty Death Record
-            DeathRecordSubmissionMessage recordSubmission = new DeathRecordSubmissionMessage(new DeathRecord());
+            DeathRecordSubmissionMessage recordSubmission = BaseMessage.Parse<DeathRecordSubmissionMessage>(FixtureStream("fixtures/json/DeathRecordSubmissionMessage.json"));
             
             // Set missing required fields
             recordSubmission.MessageSource = "http://example.fhir.org";
@@ -153,7 +154,7 @@ namespace messaging.tests
             DatabaseHelper.ResetDatabase(_context);
 
             // Create and submit a new empty Death Record
-            DeathRecordSubmissionMessage recordSubmission = new DeathRecordSubmissionMessage(new DeathRecord());
+            DeathRecordSubmissionMessage recordSubmission = BaseMessage.Parse<DeathRecordSubmissionMessage>(FixtureStream("fixtures/json/DeathRecordSubmissionMessage.json"));
 
             // Set missing required fields
             recordSubmission.MessageSource = "http://example.fhir.org";
@@ -170,7 +171,7 @@ namespace messaging.tests
             Assert.Single(response.Entry);
 
             // Get the Jurisdiction response (don't need the retries because it is known to be in the queue)
-            HttpResponseMessage jurisdictionResponse = await _client.GetAsync(MA_ENDPOINT);
+            HttpResponseMessage jurisdictionResponse = await _client.GetAsync(NY_ENDPOINT);
             response = await JsonResponseHelpers.ParseBundleAsync(jurisdictionResponse);
             Assert.Single(response.Entry);
         }
@@ -229,6 +230,47 @@ namespace messaging.tests
                 count = table.Count();
             }
             return count;
+        }
+
+        [Fact]
+        public async void PostWithNonMatchingJurisdictionsError()
+        {
+            // Clear any messages in the database for a clean test
+            DatabaseHelper.ResetDatabase(_context);
+
+            // The jurisdiction ID of the input record submission is 'NY', which should not work with a 'PA' endpoint parameter.
+            string jurisdictionParameter = "PA";
+
+            // Create a new empty Death Record
+            DeathRecordSubmissionMessage recordSubmission = BaseMessage.Parse<DeathRecordSubmissionMessage>(FixtureStream("fixtures/json/DeathRecordSubmissionMessage.json"));
+
+            // Submit that Death Record
+            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, $"/STEVE/{jurisdictionParameter}/Bundle", recordSubmission.ToJson());
+            Assert.Equal(HttpStatusCode.BadRequest, createSubmissionMessage.StatusCode);
+        }
+
+        [Fact]
+        public async void PostBatchWithNonMatchingJurisdictionsError()
+        {
+            // Clear any messages in the database for a clean test
+            DatabaseHelper.ResetDatabase(_context);
+
+            // The jurisdiction ID of the input record submission is 'MA', which should not work with a 'PA' endpoint parameter.
+            string jurisdictionParameter = "PA";
+
+            // Create a new batch message
+            string batchJson = FixtureStream("fixtures/json/BatchMessages.json").ReadToEnd();
+            HttpResponseMessage submissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, $"/STEVE/{jurisdictionParameter}/Bundles", batchJson);
+            Assert.Equal(HttpStatusCode.BadRequest, submissionMessage.StatusCode);
+        }
+
+        private StreamReader FixtureStream(string filePath)
+        {
+            if (!Path.IsPathRooted(filePath))
+            {
+                filePath = System.IO.Path.GetRelativePath(Directory.GetCurrentDirectory(), filePath);
+            }
+            return File.OpenText(filePath);
         }
     }
 }


### PR DESCRIPTION
This PR adds a check to validate the jurisdiction ID in the message submission parameter resource against the jurisdiction ID in the URL endpoint parameters.

Supports Batch `/Bundles` which will return response bundle with BadRequest entries and `/Bundle` which will just return a BadRequest.

Had to update several old tests to conform with this new validation. Most just needed a message with the parameters resource in it, some had inconsistent jurisdiction IDs that needed updating.