### PR TITLE
Query by business ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,24 +68,24 @@ The API supports several types of POST interaction:
 GET https://localhost:5001/<jurisdiction-id>/Bundle
 ```
 which returns any message response that has not been retrieved yet
-or
-```
-GET https://localhost:5001/<jurisdiction-id>/Bundle?_since=yyyy-MM-ddTHH:mm:ss.fffffff
-```
-which returns any message created after the datetime provided in the _since parameter
-or
-```
-GET https://localhost:5001/<jurisdiction-id>/Bundle?certificateNumber=xxxx&deathYear=yyyy
-```
-which returns any message that matches the given business ids: jurisidicion id, certificate number, and death year. Certificate number and death year are optional parameters, any combination of business IDs will further filter the results. When certificate number or death year are provided, it will not filter out previously retrieved messages.
+
+#### Optional Test Receive Responses GET Parameters
+
+There are 3 optional parameters that can be included in a GET request to this endpoint. They are `_since`, `certificateNumber`, and `deathYear`
+
+`_since` is to retrieve all response messages since a given timestamp. It is useful for seeing ALL message responses created in a specific time window.
+
+`deathYear` and `certificateNumber` can be used together or seperately to retrieve all message responses for the given set of business ids. It is useful for seeing the message response history for a particular record and verifying you successfully retrieved all messages during your testing.
+
+Providing any of these three search parameters may result in multiple pages of results. To make sure you retrieve all of the pages in the HTTP response, you will need to use pagination. See pagination section for details.
+
+#### NCHS API GET Request message types
 
 The API supports GET requests to retrieve responses from NCHS, including:
 
  * Acknowledgment messages acknowledging jurisdiction-submitted submission, update, and void messages
  * Error messages describing problems with jurisdiction-submitted messages
  * Coding response messages coding jurisdiction-submitted data such as cause of death, race, and ethnicity
-
-The API supports a `_since` parameter that will limit the messages returned to only message responses created since the provided timestamp.
 
 Messages flow from NCHS back to jurisdictions by jurisdiction systems polling the API looking for
 new responses. This approach of pulling responses rather than NCHS pushing responses to

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ or
 GET https://localhost:5001/<jurisdiction-id>/Bundle?_since=yyyy-MM-ddTHH:mm:ss.fffffff
 ```
 which returns any message created after the datetime provided in the _since parameter
+or
+```
+GET https://localhost:5001/<jurisdiction-id>/Bundle?certificateNumber=xxxx&deathYear=yyyy
+```
+which returns any message that matches the given business ids: jurisidicion id, certificate number, and death year.
 
 The API supports GET requests to retrieve responses from NCHS, including:
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ or
 ```
 GET https://localhost:5001/<jurisdiction-id>/Bundle?certificateNumber=xxxx&deathYear=yyyy
 ```
-which returns any message that matches the given business ids: jurisidicion id, certificate number, and death year.
+which returns any message that matches the given business ids: jurisidicion id, certificate number, and death year. Certificate number and death year are optional parameters, any combination of business IDs will further filter the results. When certificate number or death year are provided, it will not filter out previously retrieved messages.
 
 The API supports GET requests to retrieve responses from NCHS, including:
 

--- a/messaging.tests/Integration/BundlesControllerTests.cs
+++ b/messaging.tests/Integration/BundlesControllerTests.cs
@@ -59,7 +59,7 @@ namespace messaging.tests
             // This code does not have access to the background jobs, the best that can
             // be done is checking to see if the response is correct and if it is still
             // incorrect after the specified delay then assuming that something is wrong
-            for (int x = 0; x < 5; ++x) {
+            for (int x = 0; x < 7; ++x) {
                 HttpResponseMessage oneAck = await _client.GetAsync("/MA/Bundle");
                 updatedBundle = await JsonResponseHelpers.ParseBundleAsync(oneAck);
                 if (updatedBundle.Entry.Count > 0) {

--- a/messaging.tests/Integration/BundlesControllerTests.cs
+++ b/messaging.tests/Integration/BundlesControllerTests.cs
@@ -109,11 +109,8 @@ namespace messaging.tests
             HttpResponseMessage getBundle = await _client.GetAsync("/MA/Bundle?certificateNumber=" + recordSubmission.CertNo.ToString().PadLeft(6, '0') + "&deathYear=" + recordSubmission.DeathYear);
             Hl7.Fhir.Model.Bundle updatedBundle = await JsonResponseHelpers.ParseBundleAsync(getBundle);
 
-            Console.WriteLine(recordSubmission.CertNo);
-
             Assert.Equal(1, updatedBundle.Entry.Count);
             BaseMessage parsedMessage = BaseMessage.Parse<AcknowledgementMessage>((Hl7.Fhir.Model.Bundle)updatedBundle.Entry[0].Resource);
-            Console.WriteLine(parsedMessage.CertNo);
             Assert.Equal(recordSubmission.CertNo, parsedMessage.CertNo);
             Assert.Equal(recordSubmission.DeathYear, parsedMessage.DeathYear);
         }

--- a/messaging.tests/Integration/BundlesControllerTests.cs
+++ b/messaging.tests/Integration/BundlesControllerTests.cs
@@ -112,9 +112,8 @@ namespace messaging.tests
             Console.WriteLine(recordSubmission.CertNo);
 
             Assert.Equal(1, updatedBundle.Entry.Count);
-            BaseMessage parsedMessage = BaseMessage.Parse<DeathRecordSubmissionMessage>((Hl7.Fhir.Model.Bundle)updatedBundle.Entry[0].Resource);
+            BaseMessage parsedMessage = BaseMessage.Parse<AcknowledgementMessage>((Hl7.Fhir.Model.Bundle)updatedBundle.Entry[0].Resource);
             Console.WriteLine(parsedMessage.CertNo);
-            Assert.Equal(recordSubmission.MessageSource, parsedMessage.MessageSource);
             Assert.Equal(recordSubmission.CertNo, parsedMessage.CertNo);
             Assert.Equal(recordSubmission.DeathYear, parsedMessage.DeathYear);
         }

--- a/messaging.tests/Integration/BundlesControllerTests.cs
+++ b/messaging.tests/Integration/BundlesControllerTests.cs
@@ -59,7 +59,7 @@ namespace messaging.tests
             // This code does not have access to the background jobs, the best that can
             // be done is checking to see if the response is correct and if it is still
             // incorrect after the specified delay then assuming that something is wrong
-            for (int x = 0; x < 7; ++x) {
+            for (int x = 0; x < 10; ++x) {
                 HttpResponseMessage oneAck = await _client.GetAsync("/MA/Bundle");
                 updatedBundle = await JsonResponseHelpers.ParseBundleAsync(oneAck);
                 if (updatedBundle.Entry.Count > 0) {

--- a/messaging.tests/Integration/BundlesControllerTests.cs
+++ b/messaging.tests/Integration/BundlesControllerTests.cs
@@ -87,6 +87,38 @@ namespace messaging.tests
             Assert.Equal(recordSubmission.MessageId, parsedMessage.AckedMessageId);
         }
 
+                [Fact]
+        public async System.Threading.Tasks.Task QueryByBusinessIds()
+        {
+            // Clear any messages in the database for a clean test
+            DatabaseHelper.ResetDatabase(_context);
+
+            // Create a new empty Death Record
+            DeathRecordSubmissionMessage recordSubmission = new(new DeathRecord())
+            {
+                // Set missing required fields
+                MessageSource = "http://example.fhir.org",
+                CertNo = 1,
+                DeathYear = 2020
+            };
+
+            // Submit that Death Record
+            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/MA/Bundle", recordSubmission.ToJson());
+            Assert.Equal(HttpStatusCode.NoContent, createSubmissionMessage.StatusCode);
+
+            HttpResponseMessage getBundle = await _client.GetAsync("/MA/Bundle?certificateNumber=" + recordSubmission.CertNo.ToString().PadLeft(6, '0') + "&deathYear=" + recordSubmission.DeathYear);
+            Hl7.Fhir.Model.Bundle updatedBundle = await JsonResponseHelpers.ParseBundleAsync(getBundle);
+
+            Console.WriteLine(recordSubmission.CertNo);
+
+            Assert.Equal(1, updatedBundle.Entry.Count);
+            BaseMessage parsedMessage = BaseMessage.Parse<DeathRecordSubmissionMessage>((Hl7.Fhir.Model.Bundle)updatedBundle.Entry[0].Resource);
+            Console.WriteLine(parsedMessage.CertNo);
+            Assert.Equal(recordSubmission.MessageSource, parsedMessage.MessageSource);
+            Assert.Equal(recordSubmission.CertNo, parsedMessage.CertNo);
+            Assert.Equal(recordSubmission.DeathYear, parsedMessage.DeathYear);
+        }
+
         [Fact]
         public async System.Threading.Tasks.Task UnparsableMessagesCauseAnError() {
             // Clear any messages in the database for a clean test

--- a/messaging/Controllers/BundlesController.cs
+++ b/messaging/Controllers/BundlesController.cs
@@ -37,6 +37,7 @@ namespace messaging.Controllers
 
         /// <summary>
         /// Retrieves outgoing messages for the jurisdiction
+        /// If the optional Certificate Number and Death year parameters are provided, retrieves all messages in history that match those given business ids.
         /// </summary>
         /// <returns>A Bundle of FHIR messages</returns>
         /// <response code="200">Content retrieved successfully</response>
@@ -46,8 +47,7 @@ namespace messaging.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public async Task<ActionResult<Bundle>> GetOutgoingMessageItems(string jurisdictionId, int _count, DateTime _since = default(DateTime), int page = 1)
-        {
+        public async Task<ActionResult<Bundle>> GetBundle(string jurisdictionId, int _count, string certificateNumber, string deathYear, DateTime _since = default(DateTime), int page = 1) {
             if (_count == 0)
             {
                 _count = _settings.PageCount;
@@ -77,6 +77,12 @@ namespace messaging.Controllers
                 return BadRequest("Pagination does not support specifying a page without a _since parameter");
             }
 
+            return (certificateNumber == null || deathYear == null) ?
+                await GetOutgoingMessageItems(jurisdictionId, _count, _since, page) :
+                await GetMessagesWithBusinessIds(jurisdictionId, certificateNumber, Int32.Parse(deathYear), _count, _since, page);
+        }
+
+        public async Task<ActionResult<Bundle>> GetOutgoingMessageItems(string jurisdictionId, int _count, DateTime _since, int page) {
             try
             {
                 // Limit results to the jurisdiction's messages; note this just builds the query but doesn't execute until the result set is enumerated
@@ -146,6 +152,86 @@ namespace messaging.Controllers
                 foreach(OutgoingMessageItem msgItem in outgoingMessages) {
                     MarkAsRetrieved(msgItem, retrievedTime);
                 }
+                _context.SaveChanges();
+                return responseBundle;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug($"An exception occurred while retrieving the response messages: {ex}");
+                return StatusCode(500);
+            }
+        }
+
+        private async Task<ActionResult<Bundle>> GetMessagesWithBusinessIds(string jurisdictionId, string certificateNumber, int deathYear, int _count, DateTime _since, int page) {
+            try
+            {
+                // Limit results to the jurisdiction's messages; note this just builds the query but doesn't execute until the result set is enumerated
+                IQueryable<OutgoingMessageItem> outgoingMessagesQuery = _context.OutgoingMessageItems.Where(message => (message.JurisdictionId == jurisdictionId));
+
+                // Further scope the search to either unretrieved messages (or all since a specific time)
+                // TODO only allow the since param in development
+                // if _since is the default value, then apply the retrieved at logic
+                if (_since == default(DateTime))
+                {
+                    outgoingMessagesQuery = ExcludeRetrieved(outgoingMessagesQuery);
+                }
+                else
+                {
+                    outgoingMessagesQuery = outgoingMessagesQuery.Where(message => message.CreatedDate >= _since);
+                }
+
+                int totalMessageCount = outgoingMessagesQuery.Count();
+
+                // Convert to list to execute the query, capture the result for re-use
+                int numToSkip = (page - 1) * _count;
+                IEnumerable<OutgoingMessageItem> outgoingMessages = outgoingMessagesQuery.OrderBy((message) => message.RetrievedAt).Skip(numToSkip).Take(_count);
+
+                // This uses the general FHIR parser and then sees if the json is a Bundle of BaseMessage Type
+                // this will improve performance and prevent vague failures on the server, clients will be responsible for identifying incorrect messages
+                IEnumerable<System.Threading.Tasks.Task<VRDR.BaseMessage>> messageTasks = outgoingMessages.Select(message => System.Threading.Tasks.Task.Run(() => BaseMessage.ParseGenericMessage(message.Message, true)));
+
+                // create bundle to hold the response
+                Bundle responseBundle = new Bundle();
+                responseBundle.Type = Bundle.BundleType.Searchset;
+                responseBundle.Timestamp = DateTime.Now;
+                // Note that total is total number of matching results, not number being returned (outgoingMessages.Count)
+                responseBundle.Total = totalMessageCount;
+                // For the usual use case (unread only), the "next" page is just a repeated request.
+                // But when using since, we have to actually track pages
+                string baseUrl = GetNextUri();
+                if (_since == default(DateTime))
+                {
+                    // Only show the next link if there are additional messages beyond the current message set
+                    if (totalMessageCount > outgoingMessages.Count())
+                    {
+                        responseBundle.NextLink = new Uri(baseUrl + Url.Action("GetMessagesWithBusinessIds", new { jurisdictionId = jurisdictionId, certificateNumber = certificateNumber, deathYear = deathYear, _count = _count }));
+                    }
+                }
+                else
+                {
+                    var sinceFmt = _since.ToString("yyyy-MM-ddTHH:mm:ss.fffffff");
+                    responseBundle.FirstLink = new Uri(baseUrl + Url.Action("GetMessagesWithBusinessIds", new { jurisdictionId = jurisdictionId, certificateNumber = certificateNumber, deathYear = deathYear, _since = sinceFmt, _count = _count, page = 1 }));
+                    // take the total number of the original selected messages, round up, and divide by the count to get the total number of pages
+                    int lastPage = (outgoingMessagesQuery.Count() + (_count - 1)) / _count;
+                    responseBundle.LastLink = new Uri(baseUrl + Url.Action("GetMessagesWithBusinessIds", new { jurisdictionId = jurisdictionId, certificateNumber = certificateNumber, deathYear = deathYear, _since = sinceFmt, _count = _count, page = lastPage }));
+                    if (page < lastPage)
+                    {
+                        responseBundle.NextLink = new Uri(baseUrl + Url.Action("GetMessagesWithBusinessIds", new { jurisdictionId = jurisdictionId, certificateNumber = certificateNumber, deathYear = deathYear, _since = sinceFmt, _count = _count, page = page + 1 }));
+                    }
+                }
+                var messages = await System.Threading.Tasks.Task.WhenAll(messageTasks);
+                // DateTime retrievedTime = DateTime.UtcNow;
+
+                // Add messages to the bundle
+                foreach (var message in messages)
+                {
+                    responseBundle.AddResourceEntry((Bundle)message, "urn:uuid:" + message.MessageId);
+                }
+
+                // // update each outgoing message's RetrievedAt field
+                // foreach(OutgoingMessageItem msgItem in outgoingMessages) {
+                //     MarkAsRetrieved(msgItem, retrievedTime);
+                // }
                 _context.SaveChanges();
                 return responseBundle;
             }

--- a/messaging/Controllers/BundlesController.cs
+++ b/messaging/Controllers/BundlesController.cs
@@ -174,13 +174,13 @@ namespace messaging.Controllers
         /// </summary>
         /// <returns>A Bundle of FHIR messages</returns>
         private async Task<ActionResult<Bundle>> GetMessagesWithBusinessIds(string jurisdictionId, string certificateNumber, int deathYear, int _count, DateTime _since, int page)
-        {            
+        {
             try
             {
                 // Limit results to the jurisdiction's messages that match the given certificate number and death year; note this just builds the query but doesn't execute until the result set is enumerated
                 // NOTE: Should this query outgoing messages, incoming messages, or both?
                 // IQueryable<IncomingMessageItem> outgoingMessagesQuery = _context.IncomingMessageItems.Where(message => (message.JurisdictionId == jurisdictionId && message.CertificateNumber == certificateNumber && message.EventYear == deathYear));
-                IQueryable<IncomingMessageItem> outgoingMessagesQuery = _context.IncomingMessageItems.Where(message => (message.JurisdictionId == jurisdictionId && message.CertificateNumber.Equals(certificateNumber) && message.EventYear == deathYear));
+                IQueryable<OutgoingMessageItem> outgoingMessagesQuery = _context.OutgoingMessageItems.Where(message => (message.JurisdictionId == jurisdictionId && message.CertificateNumber.Equals(certificateNumber) && message.EventYear == deathYear));
 
                 // Further scope the search to either unretrieved messages (or all since a specific time)
                 // TODO only allow the since param in development
@@ -199,12 +199,7 @@ namespace messaging.Controllers
                 // Convert to list to execute the query, capture the result for re-use
                 int numToSkip = (page - 1) * _count;
 
-                // *****
-                // Using IncomingMessageItems instead of OutgoingMessageItems since certificate number and death year seem to be always be null in OutgoingMessageItems, but they probably shouldn't be? When the retrieve endpoint is hit, then IncomingMessageItems for that same message has certno/deathyear populated.
-                // Which is the correct one to check for business IDs in? Both of them? Should OutgoingMessageItems have those fields populated?
-                // *****
-                // IEnumerable<OutgoingMessageItem> outgoingMessages = outgoingMessagesQuery.OrderBy((message) => message.RetrievedAt).Skip(numToSkip).Take(_count);
-                IEnumerable<IncomingMessageItem> outgoingMessages = outgoingMessagesQuery.Skip(numToSkip).Take(_count);
+                IEnumerable<OutgoingMessageItem> outgoingMessages = outgoingMessagesQuery.OrderBy((message) => message.RetrievedAt).Skip(numToSkip).Take(_count);
 
                 // This uses the general FHIR parser and then sees if the json is a Bundle of BaseMessage Type
                 // this will improve performance and prevent vague failures on the server, clients will be responsible for identifying incorrect messages

--- a/messaging/Controllers/BundlesController.cs
+++ b/messaging/Controllers/BundlesController.cs
@@ -117,7 +117,7 @@ namespace messaging.Controllers
 
                 // Convert to list to execute the query, capture the result for re-use
                 int numToSkip = (page - 1) * _count;
-                IEnumerable<OutgoingMessageItem> outgoingMessages = outgoingMessagesQuery.OrderBy((message) => message.RetrievedAt).Skip(numToSkip).Take(_count);
+                IEnumerable<OutgoingMessageItem> outgoingMessages = outgoingMessagesQuery.OrderBy((message) => message.CreatedDate).Skip(numToSkip).Take(_count);
 
                 // This uses the general FHIR parser and then sees if the json is a Bundle of BaseMessage Type
                 // this will improve performance and prevent vague failures on the server, clients will be responsible for identifying incorrect messages

--- a/messaging/NVSSAPI/input/fsh/NVSSAPI_CapStmt.fsh
+++ b/messaging/NVSSAPI/input/fsh/NVSSAPI_CapStmt.fsh
@@ -17,4 +17,8 @@ Usage: #definition
 * rest.resource[=].interaction[0].code = #search-type
 * rest.resource[=].searchParam[0].name = "_since"
 * rest.resource[=].searchParam[=].type = #date
+* rest.resource[=].searchParam[1].name = "certificateNumber"
+* rest.resource[=].searchParam[=].type = #string
+* rest.resource[=].searchParam[2].name = "deathYear"
+* rest.resource[=].searchParam[=].type = #string
 * rest.resource[=].interaction[+].code = #create

--- a/messaging/NVSSAPI/input/fsh/NVSSAPI_CapStmt.fsh
+++ b/messaging/NVSSAPI/input/fsh/NVSSAPI_CapStmt.fsh
@@ -13,12 +13,17 @@ Usage: #definition
 * fhirVersion = #4.0.1
 * format = #json
 * rest.mode = #server
-* rest.resource[+].type = #Bundle
-* rest.resource[=].interaction[0].code = #search-type
-* rest.resource[=].searchParam[0].name = "_since"
-* rest.resource[=].searchParam[=].type = #date
-* rest.resource[=].searchParam[1].name = "certificateNumber"
-* rest.resource[=].searchParam[=].type = #string
-* rest.resource[=].searchParam[2].name = "deathYear"
-* rest.resource[=].searchParam[=].type = #string
-* rest.resource[=].interaction[+].code = #create
+* rest.resource[+]
+  * type = #Bundle
+  * interaction[+].code = #search-type
+  * interaction[+].code = #create
+  * searchParam[+]
+    * name = "_since"
+    * type = #date
+  * searchParam[+]
+    * name = "certificateNumber"
+    * type = #string
+  * searchParam[+]
+    * name = "deathYear"
+    * type = #string
+

--- a/messaging/Services/ConvertToIJEBackgroundWork.cs
+++ b/messaging/Services/ConvertToIJEBackgroundWork.cs
@@ -59,6 +59,9 @@ namespace messaging.Services
                 outgoingMessageItem.Message = errorMessage.ToJSON();
                 outgoingMessageItem.MessageId = errorMessage.MessageId;
                 outgoingMessageItem.MessageType = errorMessage.GetType().Name;
+                outgoingMessageItem.CertificateNumber = errorMessage.CertNo.ToString().PadLeft(6, '0');
+                outgoingMessageItem.EventYear = errorMessage.DeathYear;
+                outgoingMessageItem.EventType = "MOR";
                 this._context.OutgoingMessageItems.Add(outgoingMessageItem);
             }
             await this._context.SaveChangesAsync();
@@ -118,6 +121,9 @@ namespace messaging.Services
             outgoingMessageItem.Message = ackMessage.ToJSON();
             outgoingMessageItem.MessageId = ackMessage.MessageId;
             outgoingMessageItem.MessageType = ackMessage.GetType().Name;
+            outgoingMessageItem.CertificateNumber = ackMessage.CertNo.ToString().PadLeft(6, '0');
+            outgoingMessageItem.EventYear = ackMessage.DeathYear;
+            outgoingMessageItem.EventType = "MOR";
             this._context.OutgoingMessageItems.Add(outgoingMessageItem);
             this._context.SaveChanges();
         }


### PR DESCRIPTION
This PR adds the ability to query by Business IDs when both a certificateNumber and deathYear are provided on the `/Bundle` endpoint. If not both are included, then it will act as the standard endpoint to get unretrieved messages by jurisdiction ID.

Endpoint parameter options are documented in the README.
Made updates to the fsh NVSS capability statement, worth double checking to make sure that's correct.