### PR TITLE
Clean up documentation

### DIFF
--- a/APIValidationChecks.md
+++ b/APIValidationChecks.md
@@ -4,14 +4,14 @@ This file documents the API's validation checks along with the returned error co
 # Get Requests
 
 ## Parameter Validation
-Validation for the following URL parameters: `jurisdictionId` `_count` `page` `_since`
+Validation for the following URL parameters: `jurisdictionId` `_count` `page` `_since` `certificateNumber` `deathYear`
 
 | Error Response Code | parameter | Validation Check | Error Message |
 |-----|:------:|----------------|--------|
 | 400 | `jurisdictionId` | `if !VRDR.MortalityData.Instance.JurisdictionCodes.ContainsKey(jurisdictionId)` | bad request: Invalid jurisdiction ID |
 | 400 | `_count` | `if _count < 0` | bad request: _count must not be negative |
 | 400 | `page` | `if page < 1` | bad request: page must not be negative |
-| 400 | `_since` | `if (_since == default(DateTime) && page > 1)` | bad request: Pagination does not support specifying a page without a _since parameter |
+| 400 | `_since`, `certificateNumber`, `deathYear` | `if ((_since == default(DateTime) || certificateNumber == null || deathYear == null) && page > 1)` | bad request: Pagination does not support specifying a page without a `_since`, `certicateNumber`, or `deathYear` parameter |
   
    
 # POST Requests

--- a/APIValidationChecks.md
+++ b/APIValidationChecks.md
@@ -11,7 +11,7 @@ Validation for the following URL parameters: `jurisdictionId` `_count` `page` `_
 | 400 | `jurisdictionId` | `if !VRDR.MortalityData.Instance.JurisdictionCodes.ContainsKey(jurisdictionId)` | bad request: Invalid jurisdiction ID |
 | 400 | `_count` | `if _count < 0` | bad request: _count must not be negative |
 | 400 | `page` | `if page < 1` | bad request: page must not be negative |
-| 400 | `_since`, `certificateNumber`, `deathYear` | `if ((_since == default(DateTime) || certificateNumber == null || deathYear == null) && page > 1)` | bad request: Pagination does not support specifying a page without a `_since`, `certicateNumber`, or `deathYear` parameter |
+| 400 | `_since`, `certificateNumber`, `deathYear` | `if ((_since == default(DateTime) \|\| certificateNumber == null \|\| deathYear == null) && page > 1)` | bad request: Pagination does not support specifying a page without either a `_since`, `certicateNumber`, or `deathYear` parameter |
   
    
 # POST Requests

--- a/README.md
+++ b/README.md
@@ -204,14 +204,12 @@ expected:
   ID of the submission, not on the content of the message, and is the same behavior as expected
   when submitting two duplicate copies of a message to the same API.
 
-* **Duplicate Retrievals**: The NVSS FHIR APIs keep track of which messages have been retrieved via
-  GET requests. Subsequent GET requests will not retrieve messages that have already been retrieved.
-  However, the NCHS and STEVE FHIR APIs keep track of which messages have been retrieved separately
-  from each other. If a jurisdiction places a GET request through STEVE and subsequently places a
-  GET request directly to NCHS the two requests will contain duplicate messages. If for any reason a
-  client implementation needs to make requests through both channels the client is responsible for
-  ignoring duplicate messages that come through both channels using the message ID to detect
-  duplicates.
+* **Response Retrieval Queue**: The NVSS FHIR API keeps track of which messages have been retrieved via
+  GET requests. Subsequent GET requests will not retrieve messages that have already been retrieved 
+  from the queue. If a jurisdiction places a GET request through STEVE and subsequently places a
+  GET request directly to NCHS, the two requests will refer to the same queue. If for any reason a
+  client implementation needs to switch from the STEVE endpoint to the backup endpoint, it will not 
+  receive any duplicate messages when it makes the switch. 
 
 ## Authentication
 ```

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ There are 3 optional parameters that can be included in a GET request to this en
 
 `_since` is to retrieve all response messages since a given timestamp. It is useful for seeing ALL message responses created in a specific time window.
 
-`deathYear` and `certificateNumber` can be used together or seperately to retrieve all message responses for the given set of business ids. It is useful for seeing the message response history for a particular record and verifying you successfully retrieved all messages during your testing.
+`deathYear` and `certificateNumber` can be used together or seperately to retrieve all message responses for the given set of business ids. It is useful for seeing the message response history for a particular record and verifying you successfully retrieved all messages during your testing. Currently, these test parameters are only supported by the backup endpoint.
 
 Providing any of these three search parameters may result in multiple pages of results. To make sure you retrieve all of the pages in the HTTP response, you will need to use pagination. See pagination section for details.
 

--- a/messaging/Controllers/BundlesController.cs
+++ b/messaging/Controllers/BundlesController.cs
@@ -77,7 +77,7 @@ namespace messaging.Controllers
             if (!additionalParamsProvided && page > 1)
             {
                 _logger.LogError("Rejecting request with a page number but no _since parameter.");
-                return BadRequest("Pagination does not support specifying a page without a _since parameter");
+                return BadRequest("Pagination does not support specifying a page without either a _since, certificateNumber, or deathYear parameter");
             }
 
             RouteValueDictionary searchParamValues = new()


### PR DESCRIPTION
Updated docs to fix a few things
- fixed mention of the double queue in the README
- updated validation documentation to eventually give to STEVE team
- clarified in README the certificateNumber, and deathYear are only tested and approved for use with the backup endpoint, not through STEVE
- Added the new params to the pagination error response message