### PR TITLE
NCHS endpoint validation is now case insensitive

### DIFF
--- a/APIValidationChecks.md
+++ b/APIValidationChecks.md
@@ -48,7 +48,7 @@ Validates the required message headers are provided: `MessageSource`, `MessageDe
 Validates the message is not `ExtractionErrorMessage` messages since NCHS does not support them.  
 Validates the certificate number is no more than 6 characters.  
 Validates the message Event Type is a valid type accepted at NCHS: `DeathRecordSubmissionMessage`, `DeathRecordUpdateMessage`, `DeathRecordVoidMessage`, `DeathRecordAliasMessage`, or `AcknowledgementMessage`.  
-Validates the Destination Endpoint includes a valid nchs endpoint: `http://nchs.cdc.gov/vrdr_acknowledgement`, `http://nchs.cdc.gov/vrdr_alias`, `http://nchs.cdc.gov/vrdr_causeofdeath_coding`, `http://nchs.cdc.gov/vrdr_causeofdeath_coding_update`, `http://nchs.cdc.gov/vrdr_demographics_coding`, `http://nchs.cdc.gov/vrdr_demographics_coding_update`, `http://nchs.cdc.gov/vrdr_extraction_error`, `http://nchs.cdc.gov/vrdr_status`, `http://nchs.cdc.gov/vrdr_submission`, `http://nchs.cdc.gov/vrdr_submission_update`, `http://nchs.cdc.gov/vrdr_submission_void`
+Validates the Destination Endpoint includes a valid nchs endpoint, this check is case insensitive: `http://nchs.cdc.gov/vrdr_acknowledgement`, `http://nchs.cdc.gov/vrdr_alias`, `http://nchs.cdc.gov/vrdr_causeofdeath_coding`, `http://nchs.cdc.gov/vrdr_causeofdeath_coding_update`, `http://nchs.cdc.gov/vrdr_demographics_coding`, `http://nchs.cdc.gov/vrdr_demographics_coding_update`, `http://nchs.cdc.gov/vrdr_extraction_error`, `http://nchs.cdc.gov/vrdr_status`, `http://nchs.cdc.gov/vrdr_submission`, `http://nchs.cdc.gov/vrdr_submission_update`, `http://nchs.cdc.gov/vrdr_submission_void`
 
 | Error Response Code | Validation Check | Error Message |
 |-----|----------------|--------|

--- a/messaging.tests/Integration/BundlesControllerTests.cs
+++ b/messaging.tests/Integration/BundlesControllerTests.cs
@@ -558,6 +558,23 @@ namespace messaging.tests
         }
 
         [Fact]
+        public async void PostNCHSIsInDestinationEndpointListUppercase()
+        {
+            // Clear any messages in the database for a clean test
+            DatabaseHelper.ResetDatabase(_context);
+
+            // Create a new empty Death Record WITH nchs in the endpoint list
+            DeathRecordSubmissionMessage recordSubmission = new DeathRecordSubmissionMessage(new DeathRecord());
+            recordSubmission.JurisdictionId = "MA";
+            recordSubmission.MessageSource = "http://example.fhir.org";
+            recordSubmission.CertNo = 1;
+            recordSubmission.MessageDestination = "temp,http://nchs.CDC.gov/VRDR_Submission,temp";
+            // Submit that Death Record
+            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, $"/MA/Bundle", recordSubmission.ToJson());
+            Assert.Equal(HttpStatusCode.NoContent, createSubmissionMessage.StatusCode);
+        }
+
+        [Fact]
         public async void PostCatchMissingId()
         {
             // Clear any messages in the database for a clean test

--- a/messaging/Controllers/BundlesController.cs
+++ b/messaging/Controllers/BundlesController.cs
@@ -494,7 +494,8 @@ namespace messaging.Controllers
             List<string> destinationEndpoints = destination.Split(',').ToList();
             foreach (string d in destinationEndpoints)
             {
-                switch (d)
+                // set the message destination to lowercase to make the url validation case-insensitive
+                switch (d.ToLower())
                 {
                     case "http://nchs.cdc.gov/vrdr_acknowledgement":
                     case "http://nchs.cdc.gov/vrdr_alias":


### PR DESCRIPTION
This PR makes NCHS endpoint validation case insensitive.
It adds back the code reverted by:

- #72
- #71 