### PR TITLE
add max payload size to app settings

### DIFF
--- a/messaging/AppSettings.cs
+++ b/messaging/AppSettings.cs
@@ -7,4 +7,5 @@ public class AppSettings
     public string SAMS {get; set;}
     public string STEVE {get; set;}
     public int PageCount {get; set;}
+    public int MaxPayloadSize {get; set;}
 }

--- a/messaging/Startup.cs
+++ b/messaging/Startup.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.IO;
 using System;
+using Microsoft.AspNetCore.Http.Features;
 
 
 namespace messaging
@@ -28,6 +29,7 @@ namespace messaging
         public void ConfigureServices(IServiceCollection services)
         {
             services.Configure<AppSettings>(Configuration.GetSection("AppSettings"));
+
             services.AddMemoryCache();
             services.AddMiniProfiler(options => options.RouteBasePath = "/profiler").AddEntityFramework();
             services.AddDbContext<ApplicationDbContext>(opt =>
@@ -67,6 +69,7 @@ namespace messaging
                 context.Response.Headers.Add("X-XSS-Protection", "1;mode=block");
                 context.Response.Headers.Add("Cache-Control", "no-store");
                 context.Response.Headers.Add("Content-Security-Policy", "default-src");
+                context.Features.Get<IHttpMaxRequestBodySizeFeature>().MaxRequestBodySize = Int32.Parse(Configuration.GetSection("AppSettings").GetSection("MaxPayloadSize").Value);
                 await next.Invoke();
             });
             if (env.IsDevelopment())

--- a/messaging/Startup.cs
+++ b/messaging/Startup.cs
@@ -69,7 +69,12 @@ namespace messaging
                 context.Response.Headers.Add("X-XSS-Protection", "1;mode=block");
                 context.Response.Headers.Add("Cache-Control", "no-store");
                 context.Response.Headers.Add("Content-Security-Policy", "default-src");
-                context.Features.Get<IHttpMaxRequestBodySizeFeature>().MaxRequestBodySize = Int32.Parse(Configuration.GetSection("AppSettings").GetSection("MaxPayloadSize").Value);
+                // null check the MaxRequestBodySizeFeature, this feature is null in the dotnet test instance and will throw a null error in our testing framework
+                IHttpMaxRequestBodySizeFeature feat = context.Features.Get<IHttpMaxRequestBodySizeFeature>();
+                if (feat != null)
+                {
+                    feat.MaxRequestBodySize = Int32.Parse(Configuration.GetSection("AppSettings").GetSection("MaxPayloadSize").Value);
+                }
                 await next.Invoke();
             });
             if (env.IsDevelopment())

--- a/messaging/appsettings.Development.json
+++ b/messaging/appsettings.Development.json
@@ -4,7 +4,8 @@
     "BFDREnabled" : true,
     "SAMS" : "https://apigw.cdc.gov/OSELS/NCHS/NVSSFHIRAPI",
     "STEVE" : "https://ingress.devfhir.steve.naphsis.us",
-    "PageCount" : 100
+    "PageCount" : 100,
+    "MaxPayloadSize" : 10000000
   },
   "Serilog": {
     "Using": [

--- a/messaging/appsettings.Test.json
+++ b/messaging/appsettings.Test.json
@@ -4,7 +4,8 @@
     "BFDREnabled" : true,
     "SAMS" : "https://apigw.cdc.gov/OSELS/NCHS/NVSSFHIRAPI",
     "STEVE" : "https://ingress.devfhir.steve.naphsis.us",
-    "PageCount" : 100
+    "PageCount" : 100,
+    "MaxPayloadSize" : 10000000
   },
   "ConnectionStrings": {
     "NVSSMessagingDatabase": "Server=localhost;Database=nvssmessagingtest;User=sa;Password=yourStrong(!)Password;"

--- a/messaging/appsettings.json.sample
+++ b/messaging/appsettings.json.sample
@@ -4,7 +4,8 @@
     "BFDREnabled" : false,
     "SAMS" : "https://apigw.cdc.gov/OSELS/NCHS/NVSSFHIRAPI",
     "STEVE" : "https://ingress.devfhir.steve.naphsis.us",
-    "PageCount" : 100
+    "PageCount" : 100,
+    "MaxPayloadSize" : 10000000
   },
   "Serilog": {
     "Using": [


### PR DESCRIPTION
This enforces the guidance in the API README that payloads should not exceed 10MB. If jurisdictions have more messages to submit, they should submit multiple batches.