### PR TITLE
Read capability stream

### DIFF
--- a/messaging.tests/Integration/BundlesControllerTests.cs
+++ b/messaging.tests/Integration/BundlesControllerTests.cs
@@ -114,7 +114,7 @@ namespace messaging.tests
             recordSubmission.CertNo = 1;
 
             // Submit that Death Record
-            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/UT/Bundle", recordSubmission.ToJson());
+            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/UT/Bundle/BFDR/v2.0", recordSubmission.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, createSubmissionMessage.StatusCode);
 
             Hl7.Fhir.Model.Bundle updatedBundle = null;
@@ -330,7 +330,7 @@ namespace messaging.tests
             // Submit that Death Record
             HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/" + recordSubmission.JurisdictionId + "/Bundle", recordSubmission.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, createSubmissionMessage.StatusCode);
-            await System.Threading.Tasks.Task.Delay(1000);
+            await System.Threading.Tasks.Task.Delay(2000);
 
             HttpResponseMessage getBundle = await _client.GetAsync("/" + recordSubmission.JurisdictionId + "/Bundle?deathYear=" + recordSubmission.DeathYear);
             Bundle updatedBundle = await JsonResponseHelpers.ParseBundleAsync(getBundle);
@@ -456,7 +456,7 @@ namespace messaging.tests
             recordSubmission.CertNo = 1;
 
             // Submit that Death Record
-            HttpResponseMessage submissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/UT/Bundle", recordSubmission.ToJson());
+            HttpResponseMessage submissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/UT/Bundle/BFDR/v2.0", recordSubmission.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, submissionMessage.StatusCode);
 
             BirthRecordUpdateMessage recordUpdate = new BirthRecordUpdateMessage(recordSubmission.BirthRecord);
@@ -466,7 +466,7 @@ namespace messaging.tests
             recordUpdate.CertNo = 1;
 
             // Submit update message
-            HttpResponseMessage updateMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/UT/Bundle", recordUpdate.ToJson());
+            HttpResponseMessage updateMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/UT/Bundle/BFDR/v2.0", recordUpdate.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, updateMessage.StatusCode);
 
             // Make sure the ACKs made it into the queue before querying the endpoint
@@ -957,7 +957,7 @@ namespace messaging.tests
             recordSubmission2.CertNo = 1;
             recordSubmission2.MessageDestination = "http://notnchs.cdc.gov/bfdr_submission,http://nchs.cdc.gov/bfdr_submission";
             // Submit that Death Record
-            HttpResponseMessage createSubmissionMessage2 = await JsonResponseHelpers.PostJsonAsync(_client, $"/UT/Bundle", recordSubmission2.ToJson());
+            HttpResponseMessage createSubmissionMessage2 = await JsonResponseHelpers.PostJsonAsync(_client, $"/UT/Bundle/BFDR/v2.0", recordSubmission2.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, createSubmissionMessage2.StatusCode);
         }
 
@@ -986,7 +986,7 @@ namespace messaging.tests
             recordSubmission.DeathYear = 2024;
             recordSubmission2.MessageDestination = "temp,http://nchs.CDC.gov/BFDR_Submission,temp";
             // Submit that Death Record
-            HttpResponseMessage createSubmissionMessage2 = await JsonResponseHelpers.PostJsonAsync(_client, $"/MA/Bundle", recordSubmission2.ToJson());
+            HttpResponseMessage createSubmissionMessage2 = await JsonResponseHelpers.PostJsonAsync(_client, $"/MA/Bundle/BFDR/v2.0", recordSubmission2.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, createSubmissionMessage2.StatusCode);
         }
 

--- a/messaging/Controllers/BundlesController.cs
+++ b/messaging/Controllers/BundlesController.cs
@@ -506,7 +506,7 @@ namespace messaging.Controllers
         protected IncomingMessageItem ParseIncomingMessageItem(string jurisdictionId, string vitalType, Bundle bundle)
         {
             // the vital type must be specified as BFDR to post BFDR records
-            if (_settings.BFDREnabled && vitalType.Equals("BFDR"))
+            if (_settings.BFDREnabled && !String.IsNullOrEmpty(vitalType) && vitalType.Equals("BFDR"))
             {
                 try
                 {

--- a/messaging/Controllers/BundlesController.cs
+++ b/messaging/Controllers/BundlesController.cs
@@ -505,21 +505,26 @@ namespace messaging.Controllers
 
         protected IncomingMessageItem ParseIncomingMessageItem(string jurisdictionId, string vitalType, Bundle bundle)
         {
-
-            if (_settings.BFDREnabled && (String.IsNullOrEmpty(vitalType) || vitalType.Equals("BFDR")))
+            // the vital type must be specified as BFDR to post BFDR records
+            if (_settings.BFDREnabled && vitalType.Equals("BFDR"))
             {
                 try
                 {
                     CommonMessage message = BFDRBaseMessage.Parse(bundle);
                     return ValidateAndCreateIncomingMessageItem(message, jurisdictionId);
                 }
-                catch (BFDR.MessageParseException) { }
+                catch (BFDR.MessageParseException mpex) 
+                { 
+                    _logger.LogDebug($"The message could not be parsed as a BFDR message. {mpex}");
+                    throw new ArgumentException($"Failed to parse input as a BFDR message, message type unrecognized.");
+                }
                 catch (ArgumentException aex)
                 {
                     throw aex;
                 }
             }
 
+            // null vital type is considered VRDR by default
             if (String.IsNullOrEmpty(vitalType) || vitalType.Equals("VRDR"))
             {
                 try
@@ -532,15 +537,18 @@ namespace messaging.Controllers
                 {
                     throw mrx;
                 }
-                catch (VRDR.MessageParseException) { }
+                catch (VRDR.MessageParseException mpex) 
+                { 
+                    _logger.LogDebug($"The message could not be parsed as a VRDR message. {mpex}");
+                    throw new ArgumentException($"Failed to parse input as a VRDR message, message type unrecognized.");
+                }
                 catch (ArgumentException aex)
                 {
                     throw aex;
                 }
             }
 
-            _logger.LogDebug("The message could not be parsed as a BFDR or VRDR message. Throw exception.");
-            throw new ArgumentException("Failed to parse message, message type unrecognized");
+            throw new ArgumentException($"Failed to parse input as a VRDR or BFDR message, message type unrecognized.");
         }
 
         protected IncomingMessageItem ValidateAndCreateIncomingMessageItem(CommonMessage message, string jurisdictionId)

--- a/messaging/Controllers/CapStmtController.cs
+++ b/messaging/Controllers/CapStmtController.cs
@@ -48,7 +48,6 @@ namespace messaging.Controllers
                         char[] buffer = new char[2000];
                         int size = r.ReadBlock(buffer, 0, 2000);
                         string str = new string(buffer);
-                        // string str = r.ReadToEnd();
                         string customStmt = str.Replace("XX", jurisdictionId);
                         JObject json = JObject.Parse(customStmt);
                         return Ok(json);

--- a/messaging/Controllers/CapStmtController.cs
+++ b/messaging/Controllers/CapStmtController.cs
@@ -44,7 +44,11 @@ namespace messaging.Controllers
                 {
                     using (StreamReader r = new StreamReader(stream))
                     {
-                        string str = r.ReadToEnd();
+                        // the capability statement is approximately 1 kb
+                        char[] buffer = new char[2000];
+                        int size = r.ReadBlock(buffer, 0, 2000);
+                        string str = new string(buffer);
+                        // string str = r.ReadToEnd();
                         string customStmt = str.Replace("XX", jurisdictionId);
                         JObject json = JObject.Parse(customStmt);
                         return Ok(json);


### PR DESCRIPTION
Made a couple changes to address issues flagged in the security scan. The message parse exception handling can't have empty catch blocks and the stream reader for the capability statement was configured to have a maximum size.