### PR TITLE
751 - Adds support for configuring IG versions

### DIFF
--- a/messaging.tests/Integration/BundlesControllerTests.cs
+++ b/messaging.tests/Integration/BundlesControllerTests.cs
@@ -52,7 +52,7 @@ namespace messaging.tests
             recordSubmission.CertNo = 1;
 
             // Submit that Death Record
-            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/NY/Bundle/VRDR/v3.0", recordSubmission.ToJson());
+            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/NY/Bundle/VRDR/VRDR_STU3_0", recordSubmission.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, createSubmissionMessage.StatusCode);
 
             Hl7.Fhir.Model.Bundle updatedBundle = null;
@@ -60,7 +60,7 @@ namespace messaging.tests
             // be done is checking to see if the response is correct and if it is still
             // incorrect after the specified delay then assuming that something is wrong
             for (int x = 0; x < 10; ++x) {
-                HttpResponseMessage oneAck = await _client.GetAsync("/NY/Bundle/VRDR/v3.0");
+                HttpResponseMessage oneAck = await _client.GetAsync("/NY/Bundle/VRDR/VRDR_STU3_0");
                 updatedBundle = await JsonResponseHelpers.ParseBundleAsync(oneAck);
                 if (updatedBundle.Entry.Count > 0) {
                     break;
@@ -72,12 +72,12 @@ namespace messaging.tests
             Assert.Single(updatedBundle.Entry);
 
             // Check to see if the results returned for a jurisdiction other than NY does not return NY entries
-            HttpResponseMessage noMessages = await _client.GetAsync("/FL/Bundle/VRDR/v3.0");
+            HttpResponseMessage noMessages = await _client.GetAsync("/FL/Bundle/VRDR/VRDR_STU3_0");
             var noMessagesBundle = await JsonResponseHelpers.ParseBundleAsync(noMessages);
             Assert.Empty(noMessagesBundle.Entry);
 
             // Check that the retrievedAt column filters out the ACK message if we place another request
-            HttpResponseMessage noNewMsgs = await _client.GetAsync("/NY/Bundle/VRDR/v3.0");
+            HttpResponseMessage noNewMsgs = await _client.GetAsync("/NY/Bundle/VRDR/VRDR_STU3_0");
             Hl7.Fhir.Model.Bundle emptyBundle = await JsonResponseHelpers.ParseBundleAsync(noNewMsgs);
             Assert.Empty(emptyBundle.Entry);
 
@@ -112,7 +112,7 @@ namespace messaging.tests
             recordSubmission.CertNo = 1;
 
             // Submit that Death Record
-            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/UT/Bundle/BFDR-BIRTH/v2.0", recordSubmission.ToJson());
+            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/UT/Bundle/BFDR-BIRTH/BFDR_STU2_0", recordSubmission.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, createSubmissionMessage.StatusCode);
 
             Hl7.Fhir.Model.Bundle updatedBundle = null;
@@ -120,7 +120,7 @@ namespace messaging.tests
             // be done is checking to see if the response is correct and if it is still
             // incorrect after the specified delay then assuming that something is wrong
             for (int x = 0; x < 10; ++x) {
-                HttpResponseMessage oneAck = await _client.GetAsync("/UT/Bundle/BFDR-BIRTH/v2.0");
+                HttpResponseMessage oneAck = await _client.GetAsync("/UT/Bundle/BFDR-BIRTH/BFDR_STU2_0");
                 updatedBundle = await JsonResponseHelpers.ParseBundleAsync(oneAck);
                 if (updatedBundle.Entry.Count > 0) {
                     break;
@@ -137,7 +137,7 @@ namespace messaging.tests
             Assert.Empty(noMessagesBundle.Entry);
 
             // Check that the retrievedAt column filters out the ACK message if we place another request
-            HttpResponseMessage noNewMsgs = await _client.GetAsync("/UT/Bundle/BFDR-BIRTH/v2.0");
+            HttpResponseMessage noNewMsgs = await _client.GetAsync("/UT/Bundle/BFDR-BIRTH/BFDR_STU2_0");
             Hl7.Fhir.Model.Bundle emptyBundle = await JsonResponseHelpers.ParseBundleAsync(noNewMsgs);
             Assert.Empty(emptyBundle.Entry);
 
@@ -166,7 +166,7 @@ namespace messaging.tests
             recordSubmission.CertNo = 1;
 
             // Submit that Death Record
-            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/UT/Bundle/BFDR-BIRTH/v2.0", recordSubmission.ToJson());
+            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/UT/Bundle/BFDR-BIRTH/BFDR_STU2_0", recordSubmission.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, createSubmissionMessage.StatusCode);
 
             Hl7.Fhir.Model.Bundle updatedBundle = null;
@@ -174,7 +174,7 @@ namespace messaging.tests
             // be done is checking to see if the response is correct and if it is still
             // incorrect after the specified delay then assuming that something is wrong
             for (int x = 0; x < 10; ++x) {
-                HttpResponseMessage oneAck = await _client.GetAsync("/UT/Bundle/BFDR-BIRTH/v2.0");
+                HttpResponseMessage oneAck = await _client.GetAsync("/UT/Bundle/BFDR-BIRTH/BFDR_STU2_0");
                 Assert.Equal(HttpStatusCode.OK, oneAck.StatusCode);
                 updatedBundle = await JsonResponseHelpers.ParseBundleAsync(oneAck);
                 if (updatedBundle.Entry.Count > 0) {
@@ -187,12 +187,12 @@ namespace messaging.tests
             Assert.Single(updatedBundle.Entry);
 
             // Check to see if the results returned for a jurisdiction other than UT does not return UT entries
-            HttpResponseMessage noMessages = await _client.GetAsync("/FL/Bundle/BFDR-BIRTH/v2.0");
+            HttpResponseMessage noMessages = await _client.GetAsync("/FL/Bundle/BFDR-BIRTH/BFDR_STU2_0");
             var noMessagesBundle = await JsonResponseHelpers.ParseBundleAsync(noMessages);
             Assert.Empty(noMessagesBundle.Entry);
 
             // Check that the retrievedAt column filters out the ACK message if we place another request
-            HttpResponseMessage noNewMsgs = await _client.GetAsync("/UT/Bundle/BFDR-BIRTH/v2.0");
+            HttpResponseMessage noNewMsgs = await _client.GetAsync("/UT/Bundle/BFDR-BIRTH/BFDR_STU2_0");
             Hl7.Fhir.Model.Bundle emptyBundle = await JsonResponseHelpers.ParseBundleAsync(noNewMsgs);
             Assert.Empty(emptyBundle.Entry);
 
@@ -227,7 +227,7 @@ namespace messaging.tests
             recordSubmission.CertNo = 1;
 
             // Submit that Death Record
-            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/UT/Bundle/BFDR-FETALDEATH/v2.0", recordSubmission.ToJson());
+            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/UT/Bundle/BFDR-FETALDEATH/BFDR_STU2_0", recordSubmission.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, createSubmissionMessage.StatusCode);
 
             Hl7.Fhir.Model.Bundle updatedBundle = null;
@@ -235,7 +235,7 @@ namespace messaging.tests
             // be done is checking to see if the response is correct and if it is still
             // incorrect after the specified delay then assuming that something is wrong
             for (int x = 0; x < 10; ++x) {
-                HttpResponseMessage oneAck = await _client.GetAsync("/UT/Bundle/BFDR-FETALDEATH/v2.0");
+                HttpResponseMessage oneAck = await _client.GetAsync("/UT/Bundle/BFDR-FETALDEATH/BFDR_STU2_0");
                 updatedBundle = await JsonResponseHelpers.ParseBundleAsync(oneAck);
                 if (updatedBundle.Entry.Count > 0) {
                     break;
@@ -252,7 +252,7 @@ namespace messaging.tests
             Assert.Empty(noMessagesBundle.Entry);
 
             // Check that the retrievedAt column filters out the ACK message if we place another request
-            HttpResponseMessage noNewMsgs = await _client.GetAsync("/UT/Bundle/BFDR-FETALDEATH/v2.0");
+            HttpResponseMessage noNewMsgs = await _client.GetAsync("/UT/Bundle/BFDR-FETALDEATH/BFDR_STU2_0");
             Hl7.Fhir.Model.Bundle emptyBundle = await JsonResponseHelpers.ParseBundleAsync(noNewMsgs);
             Assert.Empty(emptyBundle.Entry);
 
@@ -284,10 +284,10 @@ namespace messaging.tests
             };
 
             // Submit that Death Record
-            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/" + recordSubmission.JurisdictionId + "/Bundle/VRDR/v3.0", recordSubmission.ToJson());
+            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/" + recordSubmission.JurisdictionId + "/Bundle/VRDR/VRDR_STU3_0", recordSubmission.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, createSubmissionMessage.StatusCode);
 
-            HttpResponseMessage getBundle = await _client.GetAsync("/"  + recordSubmission.JurisdictionId + "/Bundle/VRDR/v3.0?certificateNumber=" + recordSubmission.CertNo + "&deathYear=" + recordSubmission.DeathYear);
+            HttpResponseMessage getBundle = await _client.GetAsync("/"  + recordSubmission.JurisdictionId + "/Bundle/VRDR/VRDR_STU3_0?certificateNumber=" + recordSubmission.CertNo + "&deathYear=" + recordSubmission.DeathYear);
             Bundle updatedBundle = await JsonResponseHelpers.ParseBundleAsync(getBundle);
 
             Assert.Single(updatedBundle.Entry);
@@ -324,19 +324,19 @@ namespace messaging.tests
             };
 
             // Submit the Death Records
-            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/" + jurisdictionId + "/Bundle/VRDR/v3.0", recordSubmission1.ToJson());
+            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/" + jurisdictionId + "/Bundle/VRDR/VRDR_STU3_0", recordSubmission1.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, createSubmissionMessage.StatusCode);
-            createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/" + jurisdictionId + "/Bundle/VRDR/v3.0", recordSubmission2.ToJson());
+            createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/" + jurisdictionId + "/Bundle/VRDR/VRDR_STU3_0", recordSubmission2.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, createSubmissionMessage.StatusCode);
 
-            HttpResponseMessage getBundle = await _client.GetAsync("/" + jurisdictionId + "/Bundle/VRDR/v3.0?deathYear=" + deathYear + "&_count=1");
+            HttpResponseMessage getBundle = await _client.GetAsync("/" + jurisdictionId + "/Bundle/VRDR/VRDR_STU3_0?deathYear=" + deathYear + "&_count=1");
             Bundle updatedBundlePage1 = await JsonResponseHelpers.ParseBundleAsync(getBundle);
             Assert.Single(updatedBundlePage1.Entry);
             BaseMessage parsedMessage = BaseMessage.Parse<AcknowledgementMessage>((Bundle)updatedBundlePage1.Entry[0].Resource);
             Assert.Equal(recordSubmission1.CertNo, parsedMessage.CertNo);
             Assert.Equal(recordSubmission1.DeathYear, parsedMessage.DeathYear);
 
-            getBundle = await _client.GetAsync("/" + jurisdictionId + "/Bundle/VRDR/v3.0?deathYear=" + deathYear + "&_count=1&page=2");
+            getBundle = await _client.GetAsync("/" + jurisdictionId + "/Bundle/VRDR/VRDR_STU3_0?deathYear=" + deathYear + "&_count=1&page=2");
             Bundle updatedBundlePage2 = await JsonResponseHelpers.ParseBundleAsync(getBundle);
             Assert.Single(updatedBundlePage1.Entry);
             parsedMessage = BaseMessage.Parse<AcknowledgementMessage>((Bundle)updatedBundlePage2.Entry[0].Resource);
@@ -361,11 +361,11 @@ namespace messaging.tests
             };
 
             // Submit that Death Record
-            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/" + recordSubmission.JurisdictionId + "/Bundle/VRDR/v3.0", recordSubmission.ToJson());
+            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/" + recordSubmission.JurisdictionId + "/Bundle/VRDR/VRDR_STU3_0", recordSubmission.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, createSubmissionMessage.StatusCode);
             await System.Threading.Tasks.Task.Delay(1000);
 
-            HttpResponseMessage getBundle = await _client.GetAsync("/" + recordSubmission.JurisdictionId + "/Bundle/VRDR/v3.0?certificateNumber=" + recordSubmission.CertNo);
+            HttpResponseMessage getBundle = await _client.GetAsync("/" + recordSubmission.JurisdictionId + "/Bundle/VRDR/VRDR_STU3_0?certificateNumber=" + recordSubmission.CertNo);
             Bundle updatedBundle = await JsonResponseHelpers.ParseBundleAsync(getBundle);
 
             Assert.Single(updatedBundle.Entry);
@@ -391,11 +391,11 @@ namespace messaging.tests
             };
 
             // Submit that Death Record
-            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/" + recordSubmission.JurisdictionId + "/Bundle/VRDR/v3.0", recordSubmission.ToJson());
+            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/" + recordSubmission.JurisdictionId + "/Bundle/VRDR/VRDR_STU3_0", recordSubmission.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, createSubmissionMessage.StatusCode);
             await System.Threading.Tasks.Task.Delay(1000);
 
-            HttpResponseMessage getBundle = await _client.GetAsync("/" + recordSubmission.JurisdictionId + "/Bundle/VRDR/v3.0?deathYear=" + recordSubmission.DeathYear);
+            HttpResponseMessage getBundle = await _client.GetAsync("/" + recordSubmission.JurisdictionId + "/Bundle/VRDR/VRDR_STU3_0?deathYear=" + recordSubmission.DeathYear);
             Bundle updatedBundle = await JsonResponseHelpers.ParseBundleAsync(getBundle);
 
             Assert.Single(updatedBundle.Entry);
@@ -427,17 +427,17 @@ namespace messaging.tests
             recordSubmission.CertNo = 1;
 
             // Submit that Death Record
-            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/NY/Bundle/VRDR/v3.0", recordSubmission.ToJson());
+            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/NY/Bundle/VRDR/VRDR_STU3_0", recordSubmission.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, createSubmissionMessage.StatusCode);
 
             // Submit Identifical Death Record Again
-            HttpResponseMessage duplicateSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/NY/Bundle/VRDR/v3.0", recordSubmission.ToJson());
+            HttpResponseMessage duplicateSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/NY/Bundle/VRDR/VRDR_STU3_0", recordSubmission.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, duplicateSubmissionMessage.StatusCode);
 
             // Make sure the ACKs made it into the queue before querying the endpoint
             Assert.Equal(2, await GetTableCount(_context.OutgoingMessageItems, 2));
 
-            HttpResponseMessage oneAck = await _client.GetAsync("/NY/Bundle/VRDR/v3.0");
+            HttpResponseMessage oneAck = await _client.GetAsync("/NY/Bundle/VRDR/VRDR_STU3_0");
             Hl7.Fhir.Model.Bundle updatedBundle = await JsonResponseHelpers.ParseBundleAsync(oneAck);
 
             // Even though the message is a duplicate, it is still ACK'd
@@ -463,7 +463,7 @@ namespace messaging.tests
             recordSubmission.CertNo = 1;
 
             // Submit that Death Record
-            HttpResponseMessage submissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/NY/Bundle/VRDR/v3.0", recordSubmission.ToJson());
+            HttpResponseMessage submissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/NY/Bundle/VRDR/VRDR_STU3_0", recordSubmission.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, submissionMessage.StatusCode);
 
             DeathRecordUpdateMessage recordUpdate = new DeathRecordUpdateMessage(recordSubmission.DeathRecord);
@@ -473,7 +473,7 @@ namespace messaging.tests
             recordUpdate.CertNo = 1;
 
             // Submit update message
-            HttpResponseMessage updateMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/NY/Bundle/VRDR/v3.0", recordUpdate.ToJson());
+            HttpResponseMessage updateMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/NY/Bundle/VRDR/VRDR_STU3_0", recordUpdate.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, updateMessage.StatusCode);
 
             // Make sure the ACKs made it into the queue before querying the endpoint
@@ -486,7 +486,7 @@ namespace messaging.tests
             // use the since parameter to make sure we get both messages
             string since = currentTime.ToString("yyyy-MM-ddTHH:mm:ss.fffffff");
             for (int x = 0; x < 3; ++x) {
-                HttpResponseMessage getBundle = await _client.GetAsync("/NY/Bundle/VRDR/v3.0?_since=" + since);
+                HttpResponseMessage getBundle = await _client.GetAsync("/NY/Bundle/VRDR/VRDR_STU3_0?_since=" + since);
                 updatedBundle = await JsonResponseHelpers.ParseBundleAsync(getBundle);
                 // Waiting for 2 messages to appear
                 if (updatedBundle.Entry.Count > 1) {
@@ -520,7 +520,7 @@ namespace messaging.tests
             recordSubmission.EventYear = 2024;
 
             // Submit that Birth Record
-            HttpResponseMessage submissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/UT/Bundle/BFDR-BIRTH/v2.0", recordSubmission.ToJson());
+            HttpResponseMessage submissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/UT/Bundle/BFDR-BIRTH/BFDR_STU2_0", recordSubmission.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, submissionMessage.StatusCode);
 
             BirthRecordUpdateMessage recordUpdate = new BirthRecordUpdateMessage(recordSubmission.BirthRecord);
@@ -531,7 +531,7 @@ namespace messaging.tests
             recordUpdate.EventYear = 2024;
 
             // Submit update message
-            HttpResponseMessage updateMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/UT/Bundle/BFDR-BIRTH/v2.0", recordUpdate.ToJson());
+            HttpResponseMessage updateMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/UT/Bundle/BFDR-BIRTH/BFDR_STU2_0", recordUpdate.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, updateMessage.StatusCode);
 
             // Make sure the ACKs made it into the queue before querying the endpoint
@@ -544,7 +544,7 @@ namespace messaging.tests
             // use the since parameter to make sure we get both messages
             string since = currentTime.ToString("yyyy-MM-ddTHH:mm:ss.fffffff");
             for (int x = 0; x < 3; ++x) {
-                HttpResponseMessage getBundle = await _client.GetAsync("/UT/Bundle/BFDR-BIRTH/v2.0?_since=" + since);
+                HttpResponseMessage getBundle = await _client.GetAsync("/UT/Bundle/BFDR-BIRTH/BFDR_STU2_0?_since=" + since);
                 updatedBundle = await JsonResponseHelpers.ParseBundleAsync(getBundle);
                 // Waiting for 2 messages to appear
                 if (updatedBundle.Entry.Count > 1) {
@@ -600,7 +600,6 @@ namespace messaging.tests
             HttpResponseMessage submissionMessage2 = await JsonResponseHelpers.PostJsonAsync(_client, "/STEVE/MA/Bundles", batchJson);
             Assert.Equal(HttpStatusCode.OK, submissionMessage2.StatusCode);
         }
-
 
         [Fact]
         public async System.Threading.Tasks.Task ParseBatchIncomingSingleMessage()
@@ -745,7 +744,7 @@ namespace messaging.tests
           }
 
           string batchJson = batchMsg.ToJson();
-          HttpResponseMessage submissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/NY/Bundle/VRDR/v3.0", batchJson);
+          HttpResponseMessage submissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/NY/Bundle/VRDR/VRDR_STU3_0", batchJson);
           Assert.Equal(HttpStatusCode.OK, submissionMessage.StatusCode);
 
           await System.Threading.Tasks.Task.Delay(1500);
@@ -758,7 +757,7 @@ namespace messaging.tests
           // "next" link should only appear if there are more results
 
           // 1st response verify is 20 records
-          HttpResponseMessage getBundles1 = await JsonResponseHelpers.GetAsync(_client, "/NY/Bundle/VRDR/v3.0?_count=20");
+          HttpResponseMessage getBundles1 = await JsonResponseHelpers.GetAsync(_client, "/NY/Bundle/VRDR/VRDR_STU3_0?_count=20");
           Assert.Equal(HttpStatusCode.OK, getBundles1.StatusCode);
 
           FhirJsonParser parser = new FhirJsonParser();
@@ -769,7 +768,7 @@ namespace messaging.tests
           Assert.NotNull(bundle1.NextLink);
 
           // 2nd response is 20 records
-          HttpResponseMessage getBundles2 = await JsonResponseHelpers.GetAsync(_client, "/NY/Bundle/VRDR/v3.0?_count=20");
+          HttpResponseMessage getBundles2 = await JsonResponseHelpers.GetAsync(_client, "/NY/Bundle/VRDR/VRDR_STU3_0?_count=20");
           Assert.Equal(HttpStatusCode.OK, getBundles2.StatusCode);
 
           string bundleOfBundles2 = await getBundles2.Content.ReadAsStringAsync();
@@ -779,7 +778,7 @@ namespace messaging.tests
           Assert.NotNull(bundle2.NextLink);
 
           // 3rd response is 10 records
-          HttpResponseMessage getBundles3 = await JsonResponseHelpers.GetAsync(_client, "/NY/Bundle/VRDR/v3.0?_count=20");
+          HttpResponseMessage getBundles3 = await JsonResponseHelpers.GetAsync(_client, "/NY/Bundle/VRDR/VRDR_STU3_0?_count=20");
           Assert.Equal(HttpStatusCode.OK, getBundles3.StatusCode);
 
           string bundleOfBundles3 = await getBundles3.Content.ReadAsStringAsync();
@@ -789,7 +788,7 @@ namespace messaging.tests
           Assert.Null(bundle3.NextLink);
 
           // 4th response is 0 records
-          HttpResponseMessage getBundles4 = await JsonResponseHelpers.GetAsync(_client, "/NY/Bundle/VRDR/v3.0?_count=20");
+          HttpResponseMessage getBundles4 = await JsonResponseHelpers.GetAsync(_client, "/NY/Bundle/VRDR/VRDR_STU3_0?_count=20");
           Assert.Equal(HttpStatusCode.OK, getBundles4.StatusCode);
 
           string bundleOfBundles4 = await getBundles4.Content.ReadAsStringAsync();
@@ -820,7 +819,7 @@ namespace messaging.tests
           }
 
           string batchJson = batchMsg.ToJson();
-          HttpResponseMessage submissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/NY/Bundle/VRDR/v3.0", batchJson);
+          HttpResponseMessage submissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, "/NY/Bundle/VRDR/VRDR_STU3_0", batchJson);
           Assert.Equal(HttpStatusCode.OK, submissionMessage.StatusCode);
 
           await System.Threading.Tasks.Task.Delay(1500);
@@ -832,7 +831,7 @@ namespace messaging.tests
 
           // the page count should be set to 5
           // 1st response verify is 5 records
-          HttpResponseMessage getBundles = await JsonResponseHelpers.GetAsync(_client, "/NY/Bundle/VRDR/v3.0?_since=" + startTestFmt + "&_count=5");
+          HttpResponseMessage getBundles = await JsonResponseHelpers.GetAsync(_client, "/NY/Bundle/VRDR/VRDR_STU3_0?_since=" + startTestFmt + "&_count=5");
           Assert.Equal(HttpStatusCode.OK, getBundles.StatusCode);
 
           FhirJsonParser parser = new FhirJsonParser();
@@ -842,7 +841,7 @@ namespace messaging.tests
 
           // the page count should be set to 5
           // 3rd page should only have 3
-          HttpResponseMessage getBundles2 = await JsonResponseHelpers.GetAsync(_client, "/NY/Bundle/VRDR/v3.0?_since=" + startTestFmt + "&_count=5&page=4");
+          HttpResponseMessage getBundles2 = await JsonResponseHelpers.GetAsync(_client, "/NY/Bundle/VRDR/VRDR_STU3_0?_since=" + startTestFmt + "&_count=5&page=4");
           Assert.Equal(HttpStatusCode.OK, getBundles2.StatusCode);
 
           string bundleOfBundles2 = await getBundles2.Content.ReadAsStringAsync();
@@ -946,7 +945,6 @@ namespace messaging.tests
             Assert.Equal(HttpStatusCode.BadRequest, createSubmissionMessage2.StatusCode);
         }
 
-
         [Fact]
         public async void PostCatchNCHSIsNotDestinationEndpoint()
         {
@@ -1012,7 +1010,7 @@ namespace messaging.tests
             recordSubmission.CertNo = 1;
             recordSubmission.MessageDestination = "http://notnchs.cdc.gov/vrdr_submission,http://nchs.cdc.gov/vrdr_submission";
             // Submit that Death Record
-            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, $"/NY/Bundle/VRDR/v3.0", recordSubmission.ToJson());
+            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, $"/NY/Bundle/VRDR/VRDR_STU3_0", recordSubmission.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, createSubmissionMessage.StatusCode);
 
             // Create a new Birth Record WITH nchs in the endpoint list
@@ -1022,7 +1020,7 @@ namespace messaging.tests
             recordSubmission2.CertNo = 1;
             recordSubmission2.MessageDestination = "http://notnchs.cdc.gov/bfdr_submission,http://nchs.cdc.gov/bfdr_submission";
             // Submit that Death Record
-            HttpResponseMessage createSubmissionMessage2 = await JsonResponseHelpers.PostJsonAsync(_client, $"/UT/Bundle/BFDR-BIRTH/v2.0", recordSubmission2.ToJson());
+            HttpResponseMessage createSubmissionMessage2 = await JsonResponseHelpers.PostJsonAsync(_client, $"/UT/Bundle/BFDR-BIRTH/BFDR_STU2_0", recordSubmission2.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, createSubmissionMessage2.StatusCode);
         }
 
@@ -1040,7 +1038,7 @@ namespace messaging.tests
             recordSubmission.DeathYear = 2024;
             recordSubmission.MessageDestination = "temp,http://nchs.CDC.gov/VRDR_Submission,temp";
             // Submit that Death Record
-            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, $"/MA/Bundle/VRDR/v3.0", recordSubmission.ToJson());
+            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, $"/MA/Bundle/VRDR/VRDR_STU3_0", recordSubmission.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, createSubmissionMessage.StatusCode);
 
             // Create a new empty Birth Record WITH nchs in the endpoint list
@@ -1051,7 +1049,7 @@ namespace messaging.tests
             recordSubmission2.EventYear = 2024;
             recordSubmission2.MessageDestination = "temp,http://nchs.CDC.gov/BFDR_Submission,temp";
             // Submit that Death Record
-            HttpResponseMessage createSubmissionMessage2 = await JsonResponseHelpers.PostJsonAsync(_client, $"/MA/Bundle/BFDR-BIRTH/v2.0", recordSubmission2.ToJson());
+            HttpResponseMessage createSubmissionMessage2 = await JsonResponseHelpers.PostJsonAsync(_client, $"/MA/Bundle/BFDR-BIRTH/BFDR_STU2_0", recordSubmission2.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, createSubmissionMessage2.StatusCode);
         }
 
@@ -1145,14 +1143,14 @@ namespace messaging.tests
             DeathRecordSubmissionMessage recordSubmission = BaseMessage.Parse<DeathRecordSubmissionMessage>(FixtureStream("fixtures/json/DeathRecordSubmissionMessage.json"));
 
             // Submit that Death Record
-            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, $"/{jurisdictionParameter}/Bundle/VRDR/v3.0", recordSubmission.ToJson());
+            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, $"/{jurisdictionParameter}/Bundle/VRDR/VRDR_STU3_0", recordSubmission.ToJson());
             Assert.Equal(HttpStatusCode.BadRequest, createSubmissionMessage.StatusCode);
 
             // Create a new Birth Record
             BirthRecordSubmissionMessage recordSubmission2 = BFDRBaseMessage.Parse<BirthRecordSubmissionMessage>(FixtureStream("fixtures/json/BirthRecordSubmissionMessage.json"));
 
             // Submit that Birth Record
-            HttpResponseMessage createSubmissionMessage2 = await JsonResponseHelpers.PostJsonAsync(_client, $"/{jurisdictionParameter}/Bundle/BFDR-BIRTH/v2.2", recordSubmission2.ToJson());
+            HttpResponseMessage createSubmissionMessage2 = await JsonResponseHelpers.PostJsonAsync(_client, $"/{jurisdictionParameter}/Bundle/BFDR-BIRTH/VRDR_STU2_2", recordSubmission2.ToJson());
             Assert.Equal(HttpStatusCode.BadRequest, createSubmissionMessage2.StatusCode);
         }
 
@@ -1242,19 +1240,19 @@ namespace messaging.tests
             // Clear any messages in the database for a clean test
             DatabaseHelper.ResetDatabase(_context);
 
-            HttpResponseMessage response = await _client.GetAsync($"/NV/Bundle/BFDR-BIRTH/v2.2");
+            HttpResponseMessage response = await _client.GetAsync($"/NV/Bundle/BFDR-BIRTH/VRDR_STU2_2");
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
-            HttpResponseMessage response2 = await _client.GetAsync($"/NV/Bundle/VRDR/v2.0");
+            HttpResponseMessage response2 = await _client.GetAsync($"/NV/Bundle/VRDR/BFDR_STU2_0");
             Assert.Equal(HttpStatusCode.BadRequest, response2.StatusCode);
 
-            HttpResponseMessage response4 = await _client.GetAsync($"/NV/Bundle/typo/v2.2");
+            HttpResponseMessage response4 = await _client.GetAsync($"/NV/Bundle/typo/VRDR_STU2_2");
             Assert.Equal(HttpStatusCode.NotFound, response4.StatusCode);
 
-            HttpResponseMessage response5 = await _client.GetAsync($"/NV/Bundle/BFDR-FETALDEATH/v2.2");
+            HttpResponseMessage response5 = await _client.GetAsync($"/NV/Bundle/BFDR-FETALDEATH/VRDR_STU2_2");
             Assert.Equal(HttpStatusCode.BadRequest, response5.StatusCode);
 
-            HttpResponseMessage response6 = await _client.GetAsync($"/NV/Bundle/BFDR-FETALDEATH/v3.0");
+            HttpResponseMessage response6 = await _client.GetAsync($"/NV/Bundle/BFDR-FETALDEATH/VRDR_STU3_0");
             Assert.Equal(HttpStatusCode.BadRequest, response6.StatusCode);
 
             HttpResponseMessage response7 = await _client.GetAsync($"/NV/Bundle/VRDR");
@@ -1267,16 +1265,16 @@ namespace messaging.tests
             // Clear any messages in the database for a clean test
             DatabaseHelper.ResetDatabase(_context);
 
-            HttpResponseMessage response = await _client.GetAsync($"/NV/Bundle/BFDR-BIRTH/v2.0");
+            HttpResponseMessage response = await _client.GetAsync($"/NV/Bundle/BFDR-BIRTH/BFDR_STU2_0");
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-            HttpResponseMessage response2 = await _client.GetAsync($"/NV/Bundle/VRDR/v2.2");
+            HttpResponseMessage response2 = await _client.GetAsync($"/NV/Bundle/VRDR/VRDR_STU2_2");
             Assert.Equal(HttpStatusCode.OK, response2.StatusCode);
 
-            HttpResponseMessage response3 = await _client.GetAsync($"/NV/Bundle/BFDR-FETALDEATH/v2.0");
+            HttpResponseMessage response3 = await _client.GetAsync($"/NV/Bundle/BFDR-FETALDEATH/BFDR_STU2_0");
             Assert.Equal(HttpStatusCode.OK, response3.StatusCode);
 
-            HttpResponseMessage response5 = await _client.GetAsync($"/NV/Bundle/VRDR/v3.0");
+            HttpResponseMessage response5 = await _client.GetAsync($"/NV/Bundle/VRDR/VRDR_STU3_0");
             Assert.Equal(HttpStatusCode.OK, response5.StatusCode);
         }
 
@@ -1298,7 +1296,7 @@ namespace messaging.tests
             HttpResponseMessage response = await JsonResponseHelpers.PostJsonAsync(_client, "/" + recordV3_0.JurisdictionId + "/Bundle", recordV3_0.ToJson());
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
-            response = await JsonResponseHelpers.PostJsonAsync(_client, "/" + recordV3_0.JurisdictionId + "/Bundle/VRDR/v2.2", recordV3_0.ToJson());
+            response = await JsonResponseHelpers.PostJsonAsync(_client, "/" + recordV3_0.JurisdictionId + "/Bundle/VRDR/VRDR_STU2_2", recordV3_0.ToJson());
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
@@ -1308,9 +1306,9 @@ namespace messaging.tests
             // Clear any messages in the database for a clean test
             DatabaseHelper.ResetDatabase(_context);
 
-            // VRDR v2.2 record
+            // VRDR VRDR_STU2_2 record
             DeathRecordSubmissionMessage recordV2_2 = BaseMessage.Parse<DeathRecordSubmissionMessage>(FixtureStream("fixtures/json/DeathRecordSubmissionMessageV2_2.json"));
-            // VRDR v3.0 record
+            // VRDR VRDR_STU3_0 record
             DeathRecordSubmissionMessage recordV3_0 = new(new DeathRecord())
             {
                 MessageSource = "http://example.fhir.org",
@@ -1319,24 +1317,24 @@ namespace messaging.tests
                 JurisdictionId = recordV2_2.JurisdictionId
             };
 
-            // POST a v2.2 VRDR record to the default endpoint
+            // POST a VRDR_STU2_2 VRDR record to the default endpoint
             HttpResponseMessage response = await JsonResponseHelpers.PostJsonAsync(_client, $"/{recordV2_2.JurisdictionId}/Bundle", recordV2_2.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
 
-            // Make sure the record does not return for the v3.0 endpoint
-            response = await _client.GetAsync($"/{recordV2_2.JurisdictionId}/Bundle/VRDR/v3.0");
+            // Make sure the record does not return for the VRDR_STU3_0 endpoint
+            response = await _client.GetAsync($"/{recordV2_2.JurisdictionId}/Bundle/VRDR/VRDR_STU3_0");
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Hl7.Fhir.Model.Bundle bundle = await JsonResponseHelpers.ParseBundleAsync(response);
             Assert.Empty(bundle.Entry);
 
-            // Check that the record returns for the v2.2 endpoint
-            response = await _client.GetAsync($"/{recordV2_2.JurisdictionId}/Bundle/VRDR/v2.2");
+            // Check that the record returns for the VRDR_STU2_2 endpoint
+            response = await _client.GetAsync($"/{recordV2_2.JurisdictionId}/Bundle/VRDR/VRDR_STU2_2");
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             bundle = await JsonResponseHelpers.ParseBundleAsync(response);
             Assert.Single(bundle.Entry);
 
             // Make sure the record does not return now that it's been recieved
-            response = await _client.GetAsync($"/{recordV2_2.JurisdictionId}/Bundle/VRDR/v2.2");
+            response = await _client.GetAsync($"/{recordV2_2.JurisdictionId}/Bundle/VRDR/VRDR_STU2_2");
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             bundle = await JsonResponseHelpers.ParseBundleAsync(response);
             Assert.Empty(bundle.Entry);
@@ -1347,24 +1345,24 @@ namespace messaging.tests
             bundle = await JsonResponseHelpers.ParseBundleAsync(response);
             Assert.Empty(bundle.Entry);
 
-            // POST a VRDR v2.2 to the new v2.2 endpoint
-            response = await JsonResponseHelpers.PostJsonAsync(_client, $"/{recordV2_2.JurisdictionId}/Bundle/VRDR/v2.2", recordV2_2.ToJson());
+            // POST a VRDR VRDR_STU2_2 to the new VRDR_STU2_2 endpoint
+            response = await JsonResponseHelpers.PostJsonAsync(_client, $"/{recordV2_2.JurisdictionId}/Bundle/VRDR/VRDR_STU2_2", recordV2_2.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
 
-            // Make sure the record does not return for the v3.0 endpoint
-            response = await _client.GetAsync($"/{recordV2_2.JurisdictionId}/Bundle/VRDR/v3.0");
+            // Make sure the record does not return for the VRDR_STU3_0 endpoint
+            response = await _client.GetAsync($"/{recordV2_2.JurisdictionId}/Bundle/VRDR/VRDR_STU3_0");
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             bundle = await JsonResponseHelpers.ParseBundleAsync(response);
             Assert.Empty(bundle.Entry);
 
-            // Check that the record returns for the v2.2 endpoint
-            response = await _client.GetAsync($"/{recordV2_2.JurisdictionId}/Bundle/VRDR/v2.2");
+            // Check that the record returns for the VRDR_STU2_2 endpoint
+            response = await _client.GetAsync($"/{recordV2_2.JurisdictionId}/Bundle/VRDR/VRDR_STU2_2");
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             bundle = await JsonResponseHelpers.ParseBundleAsync(response);
             Assert.Single(bundle.Entry);
 
             // Make sure the record does not return now that it's been recieved
-            response = await _client.GetAsync($"/{recordV2_2.JurisdictionId}/Bundle/VRDR/v2.2");
+            response = await _client.GetAsync($"/{recordV2_2.JurisdictionId}/Bundle/VRDR/VRDR_STU2_2");
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             bundle = await JsonResponseHelpers.ParseBundleAsync(response);
             Assert.Empty(bundle.Entry);
@@ -1375,33 +1373,33 @@ namespace messaging.tests
             bundle = await JsonResponseHelpers.ParseBundleAsync(response);
             Assert.Empty(bundle.Entry);
 
-            // POST a v2.2 record to the default endpoint
+            // POST a VRDR_STU2_2 record to the default endpoint
             response = await JsonResponseHelpers.PostJsonAsync(_client, $"/{recordV2_2.JurisdictionId}/Bundle", recordV2_2.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
-            // POST a v3.0 record to the v3.0 endpoint
-            response = await JsonResponseHelpers.PostJsonAsync(_client, $"/{recordV3_0.JurisdictionId}/Bundle/VRDR/v3.0", recordV3_0.ToJson());
+            // POST a VRDR_STU3_0 record to the VRDR_STU3_0 endpoint
+            response = await JsonResponseHelpers.PostJsonAsync(_client, $"/{recordV3_0.JurisdictionId}/Bundle/VRDR/VRDR_STU3_0", recordV3_0.ToJson());
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
 
-            // Check that the v3.0 record returns from the v3.0 endpoint
-            response = await _client.GetAsync($"/{recordV3_0.JurisdictionId}/Bundle/VRDR/v3.0");
+            // Check that the VRDR_STU3_0 record returns from the VRDR_STU3_0 endpoint
+            response = await _client.GetAsync($"/{recordV3_0.JurisdictionId}/Bundle/VRDR/VRDR_STU3_0");
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             bundle = await JsonResponseHelpers.ParseBundleAsync(response);
             Assert.Single(bundle.Entry);
 
-            // Make sure the v3.0 record does not return now that it's been recieved
-            response = await _client.GetAsync($"/{recordV3_0.JurisdictionId}/Bundle/VRDR/v3.0");
+            // Make sure the VRDR_STU3_0 record does not return now that it's been recieved
+            response = await _client.GetAsync($"/{recordV3_0.JurisdictionId}/Bundle/VRDR/VRDR_STU3_0");
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             bundle = await JsonResponseHelpers.ParseBundleAsync(response);
             Assert.Empty(bundle.Entry);
 
-            // Check that the v2.2 record returns from the default endpoint
+            // Check that the VRDR_STU2_2 record returns from the default endpoint
             response = await _client.GetAsync($"/{recordV2_2.JurisdictionId}/Bundle");
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             bundle = await JsonResponseHelpers.ParseBundleAsync(response);
             Assert.Single(bundle.Entry);
 
-            // Make sure the record does not return now that it's been recieved, even in the v2.2 endpoint
-            response = await _client.GetAsync($"/{recordV2_2.JurisdictionId}/Bundle/VRDR/v2.2");
+            // Make sure the record does not return now that it's been recieved, even in the VRDR_STU2_2 endpoint
+            response = await _client.GetAsync($"/{recordV2_2.JurisdictionId}/Bundle/VRDR/VRDR_STU2_2");
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             bundle = await JsonResponseHelpers.ParseBundleAsync(response);
             Assert.Empty(bundle.Entry);
@@ -1425,4 +1423,3 @@ namespace messaging.tests
         }
     }
 }
-

--- a/messaging.tests/Integration/SteveEndpointTests.cs
+++ b/messaging.tests/Integration/SteveEndpointTests.cs
@@ -22,7 +22,7 @@ namespace messaging.tests
         private readonly ApplicationDbContext _context;
 
         private readonly string STEVE_ENDPOINT = "/STEVE/NY/Bundle";
-        private readonly string STEVE_VRDR_3_0_ENDPOINT = "/STEVE/NY/Bundle/VRDR/v3.0";
+        private readonly string STEVE_VRDR_3_0_ENDPOINT = "/STEVE/NY/Bundle/VRDR/VRDR_STU3_0";
         private readonly string NY_ENDPOINT = "/NY/Bundle";
 
         public SteveEndpointTests(CustomWebApplicationFactory<messaging.Startup> factory)
@@ -204,7 +204,7 @@ namespace messaging.tests
             Assert.Single(response.Entry);
 
             // Get the Jurisdiction response, which should be empty because the jurisdiction/STEVE queue are a single queue.
-            HttpResponseMessage jurisdictionResponse = await _client.GetAsync(NY_ENDPOINT + "/VRDR/v3.0");
+            HttpResponseMessage jurisdictionResponse = await _client.GetAsync(NY_ENDPOINT + "/VRDR/VRDR_STU3_0");
             response = await JsonResponseHelpers.ParseBundleAsync(jurisdictionResponse);
             Assert.Empty(response.Entry);
         }
@@ -222,7 +222,7 @@ namespace messaging.tests
             DeathRecordSubmissionMessage recordSubmission = new DeathRecordSubmissionMessage(new DeathRecord());
 
             // Submit that Death Record
-            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, $"/STEVE/{badJurisdiction}/Bundle/VRDR/v3.0", recordSubmission.ToJson());
+            HttpResponseMessage createSubmissionMessage = await JsonResponseHelpers.PostJsonAsync(_client, $"/STEVE/{badJurisdiction}/Bundle/VRDR/VRDR_STU3_0", recordSubmission.ToJson());
             Assert.Equal(HttpStatusCode.BadRequest, createSubmissionMessage.StatusCode);
         }
 
@@ -232,7 +232,7 @@ namespace messaging.tests
             string badJurisdiction = "AB";
             Assert.False(VR.IJEData.Instance.JurisdictionCodes.ContainsKey(badJurisdiction));
 
-            HttpResponseMessage response = await _client.GetAsync($"/STEVE/{badJurisdiction}/Bundle/VRDR/v3.0");
+            HttpResponseMessage response = await _client.GetAsync($"/STEVE/{badJurisdiction}/Bundle/VRDR/VRDR_STU3_0");
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         }
 

--- a/messaging/AppSettings.cs
+++ b/messaging/AppSettings.cs
@@ -13,17 +13,4 @@ public class AppSettings
     public int MaxPayloadSize {get; set;}
     public List<string> SupportedBFDRIGVersions {get; set;}
     public List<string> SupportedVRDRIGVersions {get; set;}
-
-    /// <summary>
-    /// Converts a paylod version in the format XXXX_STU#_# to the format v#.#
-    /// </summary>
-    /// <param name="payload"></param>
-    /// <returns></returns>
-    public static string ConvertIGPaylodVersion(string payload) {
-        string pattern = @"(?:BFDR|VRDR)_STU(\d+)_(\d+)";
-        string replacement = @"$1.$2";
-        string result = Regex.Replace(payload, pattern, replacement);
-        Console.WriteLine(result);
-        return "v" + result;
-    }
 }

--- a/messaging/AppSettings.cs
+++ b/messaging/AppSettings.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 public class AppSettings
 {
@@ -9,4 +11,19 @@ public class AppSettings
     public string STEVE {get; set;}
     public int PageCount {get; set;}
     public int MaxPayloadSize {get; set;}
+    public List<string> SupportedBFDRIGVersions {get; set;}
+    public List<string> SupportedVRDRIGVersions {get; set;}
+
+    /// <summary>
+    /// Converts a paylod version in the format XXXX_STU#_# to the format v#.#
+    /// </summary>
+    /// <param name="payload"></param>
+    /// <returns></returns>
+    public static string ConvertIGPaylodVersion(string payload) {
+        string pattern = @"(?:BFDR|VRDR)_STU(\d+)_(\d+)";
+        string replacement = @"$1.$2";
+        string result = Regex.Replace(payload, pattern, replacement);
+        Console.WriteLine(result);
+        return "v" + result;
+    }
 }

--- a/messaging/Controllers/BundlesController.cs
+++ b/messaging/Controllers/BundlesController.cs
@@ -373,14 +373,14 @@ namespace messaging.Controllers
 
         private bool ValidateIGPayloadVersion(string messagePayloadVersion, string urlParamIGVersion)
         {
-            // If the message payload is not provided, as in from an old version of messaging, then the url param must be v2.2.
-            if (String.IsNullOrEmpty(messagePayloadVersion) && urlParamIGVersion == "v2.2")
+            // If the message payload is not provided, as in from an old version of messaging, then the url param must be VRDR_STU2_2.
+            if (String.IsNullOrEmpty(messagePayloadVersion) && urlParamIGVersion == "VRDR_STU2_2")
             {
                 return true;
             }
             return messagePayloadVersion != null && urlParamIGVersion != null &&
-                    (_settings.SupportedVRDRIGVersions.Any(p => messagePayloadVersion.Equals(p) && urlParamIGVersion.Equals(AppSettings.ConvertIGPaylodVersion(p)))
-                    || _settings.SupportedBFDRIGVersions.Any(p => messagePayloadVersion.Equals(p) && urlParamIGVersion.Equals(AppSettings.ConvertIGPaylodVersion(p))));
+                    (_settings.SupportedVRDRIGVersions.Any(p => messagePayloadVersion.Equals(p) && urlParamIGVersion.Equals(p))
+                    || _settings.SupportedBFDRIGVersions.Any(p => messagePayloadVersion.Equals(p) && urlParamIGVersion.Equals(p)));
         }
 
         // InsertBatchMessage handles a single message in a batch upload submission
@@ -752,7 +752,7 @@ namespace messaging.Controllers
         }
 
         /// <summary>
-        /// Validate that the Vital Type and IG Version are valid together. If null data is provided, they default to VRDR/v2.2
+        /// Validate that the Vital Type and IG Version are valid together. If null data is provided, they default to VRDR/VRDR_STU2_2
         /// </summary>
         /// <param name="vitalType"></param>
         /// <param name="igVersion"></param>
@@ -762,9 +762,9 @@ namespace messaging.Controllers
         {
             if (String.IsNullOrEmpty(vitalType) && String.IsNullOrEmpty(igVersion))
             {
-                // If the historical backwards compatibilty endpoint is used (no vital type or ig version provided), default to VRDR v2.0
+                // If the historical backwards compatibilty endpoint is used (no vital type or ig version provided), default to VRDR_STU2_2
                 vitalType = "VRDR";
-                igVersion = "v2.2";
+                igVersion = "VRDR_STU2_2";
             }
             else if (String.IsNullOrEmpty(vitalType))
             {
@@ -810,11 +810,11 @@ namespace messaging.Controllers
         {
             if (vitalType == "BFDR-BIRTH" || vitalType == "BFDR-FETALDEATH")
             {
-                return _settings.SupportedBFDRIGVersions.Select(AppSettings.ConvertIGPaylodVersion).Contains(igVersion);
+                return _settings.SupportedBFDRIGVersions.Contains(igVersion);
             }
             else if (vitalType == "VRDR")
             {
-                return _settings.SupportedVRDRIGVersions.Select(AppSettings.ConvertIGPaylodVersion).Contains(igVersion);
+                return _settings.SupportedVRDRIGVersions.Contains(igVersion);
             }
             return false;
         }

--- a/messaging/Migrations/20250327181615_IGVersion.Designer.cs
+++ b/messaging/Migrations/20250327181615_IGVersion.Designer.cs
@@ -12,7 +12,7 @@ using messaging.Models;
 namespace messaging.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20250327181615_IGVersion")]
+    [Migration("20250512160614_IGVersion")]
     partial class IGVersion
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -66,8 +66,8 @@ namespace messaging.Migrations
                         .HasColumnType("bigint");
 
                     b.Property<string>("IGVersion")
-                        .HasMaxLength(5)
-                        .HasColumnType("CHAR(5)");
+                        .HasMaxLength(20)
+                        .HasColumnType("CHAR(20)");
 
                     b.Property<string>("JurisdictionId")
                         .IsRequired()
@@ -167,8 +167,8 @@ namespace messaging.Migrations
                         .HasColumnType("bigint");
 
                     b.Property<string>("IGVersion")
-                        .HasMaxLength(5)
-                        .HasColumnType("CHAR(5)");
+                        .HasMaxLength(20)
+                        .HasColumnType("CHAR(20)");
 
                     b.Property<string>("JurisdictionId")
                         .IsRequired()

--- a/messaging/Migrations/20250327181615_IGVersion.cs
+++ b/messaging/Migrations/20250327181615_IGVersion.cs
@@ -12,23 +12,23 @@ namespace messaging.Migrations
             migrationBuilder.AddColumn<string>(
                 name: "IGVersion",
                 table: "OutgoingMessageItems",
-                type: "CHAR(10)",
-                maxLength: 10,
+                type: "CHAR(20)",
+                maxLength: 20,
                 nullable: true);
 
             migrationBuilder.AddColumn<string>(
                 name: "IGVersion",
                 table: "IncomingMessageItems",
-                type: "CHAR(10)",
-                maxLength: 10,
+                type: "CHAR(20)",
+                maxLength: 20,
                 nullable: true);
 
             // Update IGVersion to "v2.2" for existing backwards-compatible entries where EventType equals "MOR"
-            migrationBuilder.Sql("UPDATE OutgoingMessageItems SET IGVersion = 'v2.2' WHERE EventType = 'MOR'");
-            migrationBuilder.Sql("UPDATE IncomingMessageItems SET IGVersion = 'v2.2' WHERE EventType = 'MOR'");
+            migrationBuilder.Sql("UPDATE OutgoingMessageItems SET IGVersion = 'VRDR_STU2_2' WHERE EventType = 'MOR'");
+            migrationBuilder.Sql("UPDATE IncomingMessageItems SET IGVersion = 'VRDR_STU2_2' WHERE EventType = 'MOR'");
             // Update IGVersion to "v2.0" for existing backwards-compatible entries where EventType equals "NAT" or "FET"
-            migrationBuilder.Sql("UPDATE OutgoingMessageItems SET IGVersion = 'v2.0' WHERE EventType = 'NAT' or EventType = 'FET'");
-            migrationBuilder.Sql("UPDATE IncomingMessageItems SET IGVersion = 'v2.0' WHERE EventType = 'NAT' or EventType = 'FET'");
+            migrationBuilder.Sql("UPDATE OutgoingMessageItems SET IGVersion = 'BFDR_STU2_0' WHERE EventType = 'NAT' or EventType = 'FET'");
+            migrationBuilder.Sql("UPDATE IncomingMessageItems SET IGVersion = 'BFDR_STU2_0' WHERE EventType = 'NAT' or EventType = 'FET'");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/messaging/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/messaging/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -64,8 +64,8 @@ namespace messaging.Migrations
                         .HasColumnType("bigint");
 
                     b.Property<string>("IGVersion")
-                        .HasMaxLength(5)
-                        .HasColumnType("CHAR(5)");
+                        .HasMaxLength(20)
+                        .HasColumnType("CHAR(20)");
 
                     b.Property<string>("JurisdictionId")
                         .IsRequired()
@@ -165,8 +165,8 @@ namespace messaging.Migrations
                         .HasColumnType("bigint");
 
                     b.Property<string>("IGVersion")
-                        .HasMaxLength(5)
-                        .HasColumnType("CHAR(5)");
+                        .HasMaxLength(20)
+                        .HasColumnType("CHAR(20)");
 
                     b.Property<string>("JurisdictionId")
                         .IsRequired()

--- a/messaging/Models/IncomingMessageItem.cs
+++ b/messaging/Models/IncomingMessageItem.cs
@@ -33,7 +33,7 @@ namespace messaging.Models
         [MaxLength(3)]
         public string EventType {get; set;}
         [Column(TypeName = "CHAR")]
-        [MaxLength(10)]
+        [MaxLength(20)]
         public string IGVersion { get; set; }
     }
 }

--- a/messaging/Models/OutgoingMessageItem.cs
+++ b/messaging/Models/OutgoingMessageItem.cs
@@ -29,7 +29,7 @@ namespace messaging.Models
 
         public DateTime? RetrievedAt { get; set; }
         [Column(TypeName = "CHAR")]
-        [MaxLength(5)]
+        [MaxLength(20)]
         public string IGVersion { get; set; }
     }
 }

--- a/messaging/appsettings.Development.json
+++ b/messaging/appsettings.Development.json
@@ -6,7 +6,14 @@
     "SAMS" : "https://apigw.cdc.gov/OSELS/NCHS/NVSSFHIRAPI",
     "STEVE" : "https://ingress.devfhir.steve.naphsis.us",
     "PageCount" : 100,
-    "MaxPayloadSize" : 10000000
+    "MaxPayloadSize" : 10000000,
+    "SupportedBFDRIGVersions": [
+      "BFDR_STU2_0"
+    ],
+    "SupportedVRDRIGVersions": [
+      "VRDR_STU3_0",
+      "VRDR_STU2_2"
+    ]
   },
   "Serilog": {
     "Using": [

--- a/messaging/appsettings.Test.json
+++ b/messaging/appsettings.Test.json
@@ -6,7 +6,14 @@
     "SAMS" : "https://apigw.cdc.gov/OSELS/NCHS/NVSSFHIRAPI",
     "STEVE" : "https://ingress.devfhir.steve.naphsis.us",
     "PageCount" : 100,
-    "MaxPayloadSize" : 10000000
+    "MaxPayloadSize" : 10000000,
+    "SupportedBFDRIGVersions": [
+      "BFDR_STU2_0"
+    ],
+    "SupportedVRDRIGVersions": [
+      "VRDR_STU3_0",
+      "VRDR_STU2_2"
+    ]
   },
   "ConnectionStrings": {
     "NVSSMessagingDatabase": "Server=localhost;Database=nvssmessagingtest;User=sa;Password=yourStrong(!)Password;TrustServerCertificate=True;"


### PR DESCRIPTION
This PR adds support for configuring IG Versions and update the URL param to use the PAYLOAD_VERSION format (BFDR_STU2_0) rather than the shorthand version (v2.0).
I did some iffy stuff to delete the old migration because it was causing some issues, so if that migration was applied locally you'll need to reset the database. Should be fine for the deploy since the migration was never applied there.