### PR TITLE
775 - Do strict FHIR parsing on bundles

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
       "request": "launch",
       "preLaunchTask": "build",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/messaging/bin/Debug/net5.0/messaging.dll",
+      "program": "${workspaceFolder}/messaging/bin/Debug/net6.0/messaging.dll",
       "requireExactSource": false,
       "args": [],
       "cwd": "${workspaceFolder}/messaging",

--- a/APIValidationChecks.md
+++ b/APIValidationChecks.md
@@ -30,9 +30,8 @@ Validation for the following URL parameters: `jurisdictionId`
 
 | Error Response Code | Validation Check | Error Message |
 |------|----------------|--------|
-| 400 | if parsing the generic bundle with `BaseMessage.ParseGenericBundle(text.ToString(), true);` throws an error | bad request: Failed to parse bundle. Please verify that it is consistent with the current Vital Records Messaging FHIR Implementation Guide. |
-| 400 | if parsing a generic message with `BaseMessage.Parse<BaseMessage>((Hl7.Fhir.Model.Bundle)msgBundle.Resource);` throws an error | bad request: Failed to parse message: {ex.Message}. Please verify that it is consistent with the current Vital Records Messaging FHIR Implementation Guide. |
-
+| 400 | if parsing the generic bundle with `JObject bundle = JsonConvert.DeserializeObject<JObject>(text.ToString());` throws an error | bad request: Failed to parse bundle. Please verify that it is consistent with the current Vital Records Messaging FHIR Implementation Guide. |
+| 400 | if parsing a generic message with `CommonMessage.ParseGenericBundle(resource.ToString());` throws an error | bad request: The message is not valid. {ex.Message} |
 
 ## Message Header Field Validation
 Validates the required message headers are provided: `MessageSource`, `MessageDestination`, `MessageId`, `EventType`, `CertNo` 

--- a/messaging.tests/Integration/BundlesControllerTests.cs
+++ b/messaging.tests/Integration/BundlesControllerTests.cs
@@ -873,7 +873,28 @@ namespace messaging.tests
             Assert.Equal(HttpStatusCode.BadRequest, createSubmissionMessage2.StatusCode);
         }
 
-        
+        [Fact]
+        public async void PostWithInvalidFHIRGetsError()
+        {
+            // Clear any messages in the database for a clean test
+            DatabaseHelper.ResetDatabase(_context);
+
+            // Submit Death Record with a blank string
+            string blankString = FixtureStream("fixtures/json/DeathRecordSubmissionBlankString.json").ReadToEnd();
+            HttpResponseMessage blankStringResponse = await JsonResponseHelpers.PostJsonAsync(_client, $"/UT/Bundle", blankString);
+            string blankStringBody = await blankStringResponse.Content.ReadAsStringAsync();
+
+            Assert.Equal(HttpStatusCode.BadRequest, blankStringResponse.StatusCode);
+            Assert.Contains("The property 'text' has an empty string value", blankStringBody);
+
+            // Submit Death Record with a null value
+            string nullValue = FixtureStream("fixtures/json/DeathRecordSubmissionNullValue.json").ReadToEnd();
+            HttpResponseMessage nullValueResponse = await JsonResponseHelpers.PostJsonAsync(_client, $"/UT/Bundle", nullValue);
+            string nullValueBody = await nullValueResponse.Content.ReadAsStringAsync();
+
+            Assert.Equal(HttpStatusCode.BadRequest, nullValueResponse.StatusCode);
+            Assert.Contains("The property 'text' cannot have just a null value", nullValueBody);
+        }
 
         [Fact]
         public async void PostPreservesLocalTime()

--- a/messaging.tests/fixtures/json/DeathRecordSubmissionBlankString.json
+++ b/messaging.tests/fixtures/json/DeathRecordSubmissionBlankString.json
@@ -1,0 +1,2013 @@
+{
+  "resourceType": "Bundle",
+  "id": "DeathRecordSubmissionMessage-BlankString",
+  "meta": {
+    "profile": [
+      "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-DeathRecordSubmissionMessage"
+    ]
+  },
+  "type": "message",
+  "timestamp": "2021-05-20T00:00:00Z",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "MessageHeader",
+        "id": "SubmissionHeader-Example1",
+        "meta": {
+          "profile": [
+            "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-SubmissionHeader"
+          ]
+        },
+        "eventUri": "http://nchs.cdc.gov/vrdr_submission",
+        "destination": [
+          {
+            "endpoint": "http://nchs.cdc.gov/vrdr_submission"
+          }
+        ],
+        "source": {
+          "endpoint": "https://sos.nh.gov/vitalrecords"
+        },
+        "focus": [
+          {
+            "reference": "Bundle/DeathCertificateDocument-Example1"
+          }
+        ]
+      },
+      "fullUrl": "http://www.example.org/fhir/Header/SubmissionHeader-Example1"
+    },
+    {
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "Parameters-Example1",
+        "meta": {
+          "profile": [
+            "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-MessageParameters"
+          ]
+        },
+        "parameter": [
+          {
+            "name": "jurisdiction_id",
+            "valueString": "UT"
+          },
+          {
+            "name": "cert_no",
+            "valueUnsignedInt": 22346
+          },
+          {
+            "name": "death_year",
+            "valueUnsignedInt": 2018
+          },
+          {
+            "name": "state_auxiliary_id",
+            "valueString": "abcdef10"
+          }
+        ]
+      },
+      "fullUrl": "http://www.example.org/fhir/Parameters/Parameters-Example1"
+    },
+    {
+      "resource": {
+        "resourceType": "Bundle",
+        "id": "DeathCertificateDocument-Example1",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-certificate-document"
+          ]
+        },
+        "type": "document",
+        "identifier": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/CertificateNumber",
+              "valueString": "000182"
+            },
+            {
+              "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier1",
+              "valueString": "000000000001"
+            },
+            {
+              "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier2",
+              "valueString": "100000000001"
+            }
+          ],
+          "system": "http://nchs.cdc.gov/vrdr_id",
+          "value": "2020UT000182"
+        },
+        "timestamp": "2020-10-20T14:48:35.401641-04:00",
+        "entry": [
+          {
+            "resource": {
+              "resourceType": "Composition",
+              "id": "DeathCertificate-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-certificate"
+                ]
+              },
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "64297-5",
+                    "display": "Death certificate"
+                  }
+                ]
+              },
+              "attester": [
+                {
+                  "mode": "legal",
+                  "time": "2020-11-14T16:39:40-05:00",
+                  "party": {
+                    "reference": "Practitioner/Certifier-Example1"
+                  }
+                }
+              ],
+              "event": [
+                {
+                  "code": [
+                    {
+                      "coding": [
+                        {
+                          "system": "http://snomed.info/sct",
+                          "code": "103693007"
+                        }
+                      ]
+                    }
+                  ],
+                  "detail": [
+                    {
+                      "reference": "Procedure/DeathCertification-Example1"
+                    }
+                  ]
+                }
+              ],
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/FilingFormat",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "code": "electronic"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/ReplaceStatus",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "code": "original"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/StateSpecificField",
+                  "valueString": "State Specific Content"
+                }
+              ],
+              "section": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-document-section-cs",
+                        "code": "DecedentDemographics"
+                      }
+                    ]
+                  },
+                  "entry": [
+                    {
+                      "reference": "Patient/Decedent-Example1"
+                    },
+                    {
+                      "reference": "RelatedPerson/DecedentFather-Example1"
+                    },
+                    {
+                      "reference": "RelatedPerson/DecedentMother-Example1"
+                    },
+                    {
+                      "reference": "RelatedPerson/DecedentSpouse-Example1"
+                    },
+                    {
+                      "reference": "Observation/DecedentAge-Example1"
+                    },
+                    {
+                      "reference": "Observation/BirthRecordIdentifier-Example1"
+                    },
+                    {
+                      "reference": "Observation/DecedentEducationLevel-Example1"
+                    },
+                    {
+                      "reference": "Observation/DecedentMilitaryService-Example1"
+                    },
+                    {
+                      "reference": "Observation/DecedentUsualWork-Example1"
+                    },
+                    {
+                      "reference": "Observation/InputRaceAndEthnicity-Example1"
+                    },
+                    {
+                      "reference": "Observation/EmergingIssues-Example1"
+                    }
+                  ]
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-document-section-cs",
+                        "code": "DeathInvestigation"
+                      }
+                    ]
+                  },
+                  "entry": [
+                    {
+                      "reference": "Observation/ExaminerContacted-Example1"
+                    },
+                    {
+                      "reference": "Observation/DecedentPregnancyStatus-Example1"
+                    },
+                    {
+                      "reference": "Observation/TobaccoUseContributedToDeath-Example1"
+                    },
+                    {
+                      "reference": "Observation/AutopsyPerformedIndicator-Example1"
+                    },
+                    {
+                      "reference": "Location/DeathLocation-Example1"
+                    },
+                    {
+                      "reference": "Location/InjuryLocation-Example1"
+                    },
+                    {
+                      "reference": "Observation/InjuryIncident-Example1"
+                    },
+                    {
+                      "reference": "Observation/DeathDate-Example1"
+                    },
+                    {
+                      "reference": "Observation/SurgeryDate-Example1"
+                    }
+                  ]
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-document-section-cs",
+                        "code": "DeathCertification"
+                      }
+                    ]
+                  },
+                  "entry": [
+                    {
+                      "reference": "Practitioner/Certifier-Example1"
+                    },
+                    {
+                      "reference": "Procedure/DeathCertification-Example1"
+                    },
+                    {
+                      "reference": "Observation/MannerOfDeath-Example1"
+                    },
+                    {
+                      "reference": "Observation/CauseOfDeathPart1-Example1"
+                    },
+                    {
+                      "reference": "Observation/CauseOfDeathPart1-Example2"
+                    },
+                    {
+                      "reference": "Observation/CauseOfDeathPart2-Example1"
+                    }
+                  ]
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-document-section-cs",
+                        "code": "DecedentDisposition"
+                      }
+                    ]
+                  },
+                  "entry": [
+                    {
+                      "reference": "Location/DispositionLocation-Example1"
+                    },
+                    {
+                      "reference": "Organization/FuneralHome-Example1"
+                    },
+                    {
+                      "reference": "Observation/DecedentDispositionMethod-Example1"
+                    },
+                    {
+                      "reference": "Practitioner/Mortician-Example1"
+                    }
+                  ]
+                }
+              ],
+              "status": "final",
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "date": "2020-11-15T16:39:54-05:00",
+              "author": [
+                {
+                  "reference": "Practitioner/Certifier-Example1"
+                }
+              ],
+              "title": "Death Certificate"
+            },
+            "fullUrl": "http://www.example.org/fhir/Bundle/DeathCertificate-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Patient",
+              "id": "Decedent-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent"
+                ]
+              },
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/SpouseAlive",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "code": "Y",
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/NVSS-SexAtDeath",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "code": "unknown",
+                        "system": "http://hl7.org/fhir/administrative-gender",
+                        "display": "Unknown"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/patient-birthPlace",
+                  "valueAddress": {
+                    "city": "Roanoke",
+                    "state": "VA",
+                    "country": "US"
+                  }
+                }
+              ],
+              "address": [
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/WithinCityLimitsIndicator",
+                      "valueCoding": {
+                        "code": "Y",
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                        "display": "Yes"
+                      }
+                    },
+                    {
+                      "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/StreetName",
+                      "valueString": "Lockwood"
+                    }
+                  ],
+                  "line": [
+                    "5590 Lockwood Drive"
+                  ],
+                  "city": "Danville",
+                  "_city": {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/CityCode",
+                        "valuePositiveInt": 1234
+                      }
+                    ]
+                  },
+                  "state": "VA",
+                  "district": "Fairfax",
+                  "_district": {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/DistrictCode",
+                        "valuePositiveInt": 321
+                      }
+                    ]
+                  },
+                  "country": "US"
+                }
+              ],
+              "maritalStatus": {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/BypassEditFlag",
+                    "valueCodeableConcept": {
+                      "coding": [
+                        {
+                          "code": "0",
+                          "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-bypass-edit-flag-cs",
+                          "display": "Edit Passed"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "coding": [
+                  {
+                    "code": "S",
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus",
+                    "display": "Never Married"
+                  }
+                ]
+              },
+              "identifier": [
+                {
+                  "type": {
+                    "coding": [
+                      {
+                        "code": "SB",
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                        "display": "Social Beneficiary Identifier"
+                      }
+                    ]
+                  },
+                  "system": "http://hl7.org/fhir/sid/us-ssn",
+                  "value": "987654321"
+                }
+              ],
+              "name": [
+                {
+                  "use": "official",
+                  "family": "Patel",
+                  "given": [
+                    "Madelyn"
+                  ]
+                }
+              ],
+              "gender": "female",
+              "contact": [
+                {
+                  "name": {
+                    "text": "Joe Smith"
+                  },
+                  "relationship": [
+                    {
+                      "text": "Friend of family"
+                    }
+                  ]
+                }
+              ],
+              "_birthDate": {
+                "extension": [
+                  {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Day",
+                        "valueUnsignedInt": 10
+                      },
+                      {
+                        "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Year",
+                        "valueUnsignedInt": 2004
+                      },
+                      {
+                        "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Month",
+                        "valueUnsignedInt": 11
+                      }
+                    ],
+                    "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/PartialDate"
+                  }
+                ]
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Patient/Decedent-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "RelatedPerson",
+              "id": "DecedentFather-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-father"
+                ]
+              },
+              "relationship": [
+                {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                      "code": "FTH"
+                    }
+                  ]
+                }
+              ],
+              "patient": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "name": [
+                {
+                  "text": "Decedent Dad",
+                  "use": "official",
+                  "given": [
+                    "John"
+                  ],
+                  "family": "Smith",
+                  "suffix": [
+                    "Sr"
+                  ]
+                }
+              ]
+            },
+            "fullUrl": "http://www.example.org/fhir/RelatedPerson/DecedentFather-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "RelatedPerson",
+              "id": "DecedentMother-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-mother"
+                ]
+              },
+              "relationship": [
+                {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                      "code": "MTH"
+                    }
+                  ]
+                }
+              ],
+              "patient": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "name": [
+                {
+                  "text": "Decedent Mom",
+                  "use": "maiden",
+                  "given": [
+                    "Jane"
+                  ],
+                  "family": "Suzette"
+                }
+              ]
+            },
+            "fullUrl": "http://www.example.org/fhir/RelatedPerson/DecedentMother-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "RelatedPerson",
+              "id": "DecedentSpouse-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-spouse"
+                ]
+              },
+              "relationship": [
+                {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                      "code": "SPS"
+                    }
+                  ]
+                }
+              ],
+              "patient": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "name": [
+                {
+                  "text": "Decedent Spouse",
+                  "use": "maiden",
+                  "given": [
+                    "Samuel"
+                  ],
+                  "family": "Gazette",
+                  "suffix": [
+                    "III"
+                  ]
+                }
+              ]
+            },
+            "fullUrl": "http://www.example.org/fhir/RelatedPerson/DecedentSpouse-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "DecedentAge-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-age"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "39016-1"
+                  }
+                ]
+              },
+              "valueQuantity": {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/BypassEditFlag",
+                    "valueCodeableConcept": {
+                      "coding": [
+                        {
+                          "code": "0",
+                          "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-bypass-edit-flag-cs",
+                          "display": "Edit Passed"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "value": 42,
+                "unit": "a"
+              },
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/DecedentAge-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "InputRaceAndEthnicity-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-input-race-and-ethnicity"
+                ]
+              },
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-observations-cs",
+                    "code": "inputraceandethnicity"
+                  }
+                ]
+              },
+              "component": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "White"
+                      }
+                    ]
+                  },
+                  "valueBoolean": true
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "BlackOrAfricanAmerican"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "AmericanIndianOrAlaskanNative"
+                      }
+                    ]
+                  },
+                  "valueBoolean": true
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "AsianIndian"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "Chinese"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "Filipino"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "Japanese"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "Korean"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "Vietnamese"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "OtherAsian"
+                      }
+                    ]
+                  },
+                  "valueBoolean": true
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "NativeHawaiian"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "GuamanianOrChamorro"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "Samoan"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "OtherPacificIslander"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "OtherRace"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "FirstOtherAsianLiteral"
+                      }
+                    ]
+                  },
+                  "valueString": "Malaysian"
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "FirstAmericanIndianOrAlaskanNativeLiteral"
+                      }
+                    ]
+                  },
+                  "valueString": "Arikara"
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "HispanicMexican"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "code": "Y",
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                        "display": "Yes"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "HispanicCuban"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "code": "Y",
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                        "display": "No"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "HispanicPuertoRican"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "code": "Y",
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                        "display": "Yes"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "HispanicOther"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "code": "N",
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                        "display": "No"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "status": "final",
+              "subject": {
+                "display": "NCHS generated"
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/InputRaceAndEthnicity-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "BirthRecordIdentifier-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-birth-record-identifier"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                    "code": "BR",
+                    "display": "Birth registry number"
+                  }
+                ]
+              },
+              "component": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://loinc.org",
+                        "code": "21842-0"
+                      }
+                    ]
+                  },
+                  "valueString": "YC"
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://loinc.org",
+                        "code": "80904-6"
+                      }
+                    ]
+                  },
+                  "valueDateTime": "1961"
+                }
+              ],
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "valueString": "717171"
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/BirthRecordIdentifier-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "DecedentEducationLevel-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-education-level"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "80913-7"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "code": "SEC",
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-EducationLevel",
+                    "display": "Some secondary or high school education"
+                  }
+                ]
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/DecedentEducationLevel-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "DecedentMilitaryService-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-military-service"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "55280-2"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "code": "Y",
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                    "display": "Yes"
+                  }
+                ]
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/DecedentMilitaryService-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "DecedentUsualWork-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-usual-work"
+                ]
+              },
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "21843-8"
+                  }
+                ]
+              },
+              "component": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://loinc.org",
+                        "code": "21844-6",
+                        "display": "History of Usual industry"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "text": "State agency",
+                    "coding": [
+                      {
+                        "code": "UNK",
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                        "display": "unknown"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "status": "final",
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "valueCodeableConcept": {
+                "text": "secretary",
+                "coding": [
+                  {
+                    "code": "UNK",
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                    "display": "unknown"
+                  }
+                ]
+              },
+              "effectivePeriod": {
+                "start": "2001",
+                "end": "2005"
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/DecedentUsualWork-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "EmergingIssues-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-emerging-issues"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-observations-cs",
+                    "code": "emergingissues"
+                  }
+                ]
+              },
+              "component": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "EmergingIssue1_1"
+                      }
+                    ]
+                  },
+                  "valueString": "H"
+                }
+              ],
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/EmergingIssues-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "DecedentPregnancyStatus-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-pregnancy-status"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "69442-2"
+                  }
+                ]
+              },
+              "valueCodeableConcept": {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/BypassEditFlag",
+                    "valueCodeableConcept": {
+                      "coding": [
+                        {
+                          "code": "2",
+                          "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-bypass-edit-flag-cs",
+                          "display": "Edit Failed, Data Queried, but not Verified"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "coding": [
+                  {
+                    "code": "2",
+                    "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-pregnancy-status-cs",
+                    "display": "Pregnant at time of death"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/DecedentPregnancyStatus-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "TobaccoUseContributedToDeath-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-tobacco-use-contributed-to-death"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "69443-0",
+                    "display": "Did tobacco use contribute to death"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "code": "373066001",
+                    "system": "http://snomed.info/sct",
+                    "display": "Yes"
+                  }
+                ]
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/TobaccoUseContributedToDeath-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "DeathDate-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-date"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "81956-5"
+                  }
+                ]
+              },
+              "component": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://loinc.org",
+                        "code": "80616-6"
+                      }
+                    ]
+                  },
+                  "valueDateTime": "2020-11-13T16:39:40-05:00"
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://loinc.org",
+                        "code": "58332-8"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "code": "16983000",
+                        "system": "http://snomed.info/sct",
+                        "display": "Death in hospital"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "effectiveDateTime": "2020-11-12T16:39:40-05:00",
+              "performer": [
+                {
+                  "reference": "Practitioner/Certifier-Example1"
+                }
+              ],
+              "_valueDateTime": {
+                "extension": [
+                  {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Day",
+                        "valueUnsignedInt": 12
+                      },
+                      {
+                        "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Year",
+                        "valueUnsignedInt": 2020
+                      },
+                      {
+                        "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Month",
+                        "valueUnsignedInt": 11
+                      },
+                      {
+                        "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Time",
+                        "_valueTime": {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                              "valueCode": "unknown"
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/PartialDateTime"
+                  }
+                ]
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/DeathDate-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "SurgeryDate-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-surgery-date"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "80992-1"
+                  }
+                ]
+              },
+              "effectiveDateTime": "2019-11-12",
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/SurgeryDate-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "ExaminerContacted-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-examiner-contacted"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "74497-9"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "code": "Y",
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                    "display": "Yes"
+                  }
+                ]
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/ExaminerContacted-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "MannerOfDeath-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-manner-of-death"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "69449-7"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "code": "38605008",
+                    "system": "http://snomed.info/sct",
+                    "display": "Natural death"
+                  }
+                ]
+              },
+              "performer": [
+                {
+                  "reference": "Practitioner/Certifier-Example1"
+                }
+              ]
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/MannerOfDeath-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Location",
+              "id": "DeathLocation-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-location"
+                ]
+              },
+              "type": [
+                {
+                  "coding": [
+                    {
+                      "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
+                      "code": "death"
+                    }
+                  ]
+                }
+              ],
+              "name": "Pecan Grove Nursing Home",
+              "description": "nursing home",
+              "address": {
+                "city": "Albany",
+                "state": "NY",
+                "country": "US"
+              },
+              "position": {
+                "latitude": 38.889248,
+                "longitude": -77.050636
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Location/DeathLocation-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Location",
+              "id": "InjuryLocation-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-injury-location"
+                ]
+              },
+              "type": [
+                {
+                  "coding": [
+                    {
+                      "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
+                      "code": "injury"
+                    }
+                  ]
+                }
+              ],
+              "description": "5590 Lockwood Drive 20621 US",
+              "name": "Home",
+              "address": {
+                "text": "5590 Lockwood Drive 20621 US"
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Location/InjuryLocation-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "InjuryIncident-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-injury-incident"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "11374-6"
+                  }
+                ]
+              },
+              "component": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://loinc.org",
+                        "code": "69444-8"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "code": "N",
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                        "display": "No"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://loinc.org",
+                        "code": "69450-5"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "text": "Home"
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://loinc.org",
+                        "code": "69451-3"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "code": "OTH",
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                        "display": "Other"
+                      }
+                    ],
+                    "text": "Hoverboard Rider"
+                  }
+                }
+              ],
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "effectiveDateTime": "2019-11-02T13:00:00-05:00",
+              "valueCodeableConcept": {
+                "text": "drug toxicity"
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/InjuryIncident-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Practitioner",
+              "id": "Certifier-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-certifier"
+                ]
+              },
+              "name": [
+                {
+                  "use": "official",
+                  "family": "Black",
+                  "given": [
+                    "Jim"
+                  ]
+                }
+              ],
+              "address": [
+                {
+                  "line": [
+                    "44 South Street"
+                  ],
+                  "city": "Bird in Hand",
+                  "state": "PA",
+                  "postalCode": "17505",
+                  "country": "US"
+                }
+              ],
+              "identifier": [
+                {
+                  "system": "http://hl7.org/fhir/sid/us-npi",
+                  "value": "414444AB"
+                }
+              ],
+              "qualification": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "code": "434641000124105",
+                        "system": "http://snomed.info/sct"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "fullUrl": "http://www.example.org/fhir/Practitioner/Certifier-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Procedure",
+              "id": "DeathCertification-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-certification"
+                ]
+              },
+              "status": "completed",
+              "category": {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "103693007",
+                    "display": "Diagnostic procedure"
+                  }
+                ]
+              },
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "308646001",
+                    "display": "Death certification"
+                  }
+                ]
+              },
+              "identifier": [
+                {
+                  "value": "180"
+                }
+              ],
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "performedDateTime": "2020-11-14T16:39:40-05:00",
+              "performer": [
+                {
+                  "function": {
+                    "coding": [
+                      {
+                        "code": "OTH",
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                        "display": "Other"
+                      }
+                    ],
+                    "text": "Nurse Practitioner"
+                  },
+                  "actor": {
+                    "reference": "Practitioner/Certifier-Example1"
+                  }
+                }
+              ]
+            },
+            "fullUrl": "http://www.example.org/fhir/Procedure/DeathCertification-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "CauseOfDeathPart1-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1"
+                ]
+              },
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "69453-9"
+                  }
+                ]
+              },
+              "component": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "lineNumber"
+                      }
+                    ]
+                  },
+                  "valueInteger": 1
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://loinc.org",
+                        "code": "69440-6"
+                      }
+                    ]
+                  },
+                  "valueString": "4 hours"
+                }
+              ],
+              "valueCodeableConcept": {
+                "text": ""
+              },
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "performer": [
+                {
+                  "reference": "Practitioner/Certifier-Example1"
+                }
+              ],
+              "status": "final"
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/CauseOfDeathPart1-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "CauseOfDeathPart1-Example2",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1"
+                ]
+              },
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "69453-9"
+                  }
+                ]
+              },
+              "component": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "lineNumber"
+                      }
+                    ]
+                  },
+                  "valueInteger": 2
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://loinc.org",
+                        "code": "69440-6"
+                      }
+                    ]
+                  },
+                  "valueString": "3 months"
+                }
+              ],
+              "valueCodeableConcept": {
+                "text": "Eclampsia"
+              },
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "performer": [
+                {
+                  "reference": "Practitioner/Certifier-Example1"
+                }
+              ],
+              "status": "final"
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/CauseOfDeathPart1-Example2"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "CauseOfDeathPart2-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part2"
+                ]
+              },
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "69441-4"
+                  }
+                ]
+              },
+              "valueCodeableConcept": {
+                "text": "hypertensive heart disease"
+              },
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "performer": [
+                {
+                  "reference": "Practitioner/Certifier-Example1"
+                }
+              ],
+              "status": "final"
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/CauseOfDeathPart2-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Location",
+              "id": "DispositionLocation-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-disposition-location"
+                ]
+              },
+              "type": [
+                {
+                  "coding": [
+                    {
+                      "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
+                      "code": "disposition"
+                    }
+                  ]
+                }
+              ],
+              "name": "Rosewood Cemetary",
+              "address": {
+                "line": [
+                  "303 Rosewood Ave"
+                ],
+                "city": "Danville",
+                "state": "VA",
+                "postalCode": "24541",
+                "country": "US"
+              },
+              "physicalType": {
+                "coding": [
+                  {
+                    "code": "si",
+                    "system": "http://terminology.hl7.org/CodeSystem/location-physical-type",
+                    "display": "Site"
+                  }
+                ]
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Location/DispositionLocation-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Organization",
+              "id": "FuneralHome-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-funeral-home"
+                ]
+              },
+              "type": [
+                {
+                  "coding": [
+                    {
+                      "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-organization-type-cs",
+                      "code": "funeralhome",
+                      "display": "Funeral Home"
+                    }
+                  ]
+                }
+              ],
+              "active": true,
+              "name": "Lancaster Funeral Home and Crematory",
+              "address": [
+                {
+                  "line": [
+                    "211 High Street"
+                  ],
+                  "city": "Lancaster",
+                  "state": "PA",
+                  "postalCode": "17573",
+                  "country": "US"
+                }
+              ]
+            },
+            "fullUrl": "http://www.example.org/fhir/Organization/FuneralHome-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "DecedentDispositionMethod-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-disposition-method"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "80905-3"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "performer": [
+                {
+                  "reference": "Practitioner/Mortician-Example1"
+                }
+              ],
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "code": "449971000124106",
+                    "system": "http://snomed.info/sct",
+                    "display": "Burial"
+                  }
+                ]
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/DecedentDispositionMethod-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "AutopsyPerformedIndicator-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-autopsy-performed-indicator"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "85699-7"
+                  }
+                ]
+              },
+              "component": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://loinc.org",
+                        "code": "69436-4"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "code": "Y",
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                        "display": "Yes"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "code": "Y",
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                    "display": "Yes"
+                  }
+                ]
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/AutopsyPerformedIndicator-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Practitioner",
+              "id": "Mortician-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+                ]
+              },
+              "identifier": [
+                {
+                  "system": "http://hl7.org/fhir/sid/us-npi",
+                  "value": "212222AB"
+                }
+              ],
+              "name": [
+                {
+                  "use": "official",
+                  "family": "Smith",
+                  "given": [
+                    "Ronald",
+                    "Q"
+                  ]
+                }
+              ]
+            },
+            "fullUrl": "http://www.example.org/fhir/Practitioner/Mortician-Example1"
+          }
+        ]
+      },
+      "fullUrl": "http://www.example.org/fhir/Bundle/DeathCertificateDocument-Example1"
+    }
+  ]
+}

--- a/messaging.tests/fixtures/json/DeathRecordSubmissionNullValue.json
+++ b/messaging.tests/fixtures/json/DeathRecordSubmissionNullValue.json
@@ -1,0 +1,2013 @@
+{
+  "resourceType": "Bundle",
+  "id": "DeathRecordSubmissionMessage-BlankString",
+  "meta": {
+    "profile": [
+      "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-DeathRecordSubmissionMessage"
+    ]
+  },
+  "type": "message",
+  "timestamp": "2021-05-20T00:00:00Z",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "MessageHeader",
+        "id": "SubmissionHeader-Example1",
+        "meta": {
+          "profile": [
+            "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-SubmissionHeader"
+          ]
+        },
+        "eventUri": "http://nchs.cdc.gov/vrdr_submission",
+        "destination": [
+          {
+            "endpoint": "http://nchs.cdc.gov/vrdr_submission"
+          }
+        ],
+        "source": {
+          "endpoint": "https://sos.nh.gov/vitalrecords"
+        },
+        "focus": [
+          {
+            "reference": "Bundle/DeathCertificateDocument-Example1"
+          }
+        ]
+      },
+      "fullUrl": "http://www.example.org/fhir/Header/SubmissionHeader-Example1"
+    },
+    {
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "Parameters-Example1",
+        "meta": {
+          "profile": [
+            "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-MessageParameters"
+          ]
+        },
+        "parameter": [
+          {
+            "name": "jurisdiction_id",
+            "valueString": "UT"
+          },
+          {
+            "name": "cert_no",
+            "valueUnsignedInt": 22346
+          },
+          {
+            "name": "death_year",
+            "valueUnsignedInt": 2018
+          },
+          {
+            "name": "state_auxiliary_id",
+            "valueString": "abcdef10"
+          }
+        ]
+      },
+      "fullUrl": "http://www.example.org/fhir/Parameters/Parameters-Example1"
+    },
+    {
+      "resource": {
+        "resourceType": "Bundle",
+        "id": "DeathCertificateDocument-Example1",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-certificate-document"
+          ]
+        },
+        "type": "document",
+        "identifier": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/CertificateNumber",
+              "valueString": "000182"
+            },
+            {
+              "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier1",
+              "valueString": "000000000001"
+            },
+            {
+              "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/AuxiliaryStateIdentifier2",
+              "valueString": "100000000001"
+            }
+          ],
+          "system": "http://nchs.cdc.gov/vrdr_id",
+          "value": "2020UT000182"
+        },
+        "timestamp": "2020-10-20T14:48:35.401641-04:00",
+        "entry": [
+          {
+            "resource": {
+              "resourceType": "Composition",
+              "id": "DeathCertificate-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-certificate"
+                ]
+              },
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "64297-5",
+                    "display": "Death certificate"
+                  }
+                ]
+              },
+              "attester": [
+                {
+                  "mode": "legal",
+                  "time": "2020-11-14T16:39:40-05:00",
+                  "party": {
+                    "reference": "Practitioner/Certifier-Example1"
+                  }
+                }
+              ],
+              "event": [
+                {
+                  "code": [
+                    {
+                      "coding": [
+                        {
+                          "system": "http://snomed.info/sct",
+                          "code": "103693007"
+                        }
+                      ]
+                    }
+                  ],
+                  "detail": [
+                    {
+                      "reference": "Procedure/DeathCertification-Example1"
+                    }
+                  ]
+                }
+              ],
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/FilingFormat",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "code": "electronic"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/ReplaceStatus",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "code": "original"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/StateSpecificField",
+                  "valueString": "State Specific Content"
+                }
+              ],
+              "section": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-document-section-cs",
+                        "code": "DecedentDemographics"
+                      }
+                    ]
+                  },
+                  "entry": [
+                    {
+                      "reference": "Patient/Decedent-Example1"
+                    },
+                    {
+                      "reference": "RelatedPerson/DecedentFather-Example1"
+                    },
+                    {
+                      "reference": "RelatedPerson/DecedentMother-Example1"
+                    },
+                    {
+                      "reference": "RelatedPerson/DecedentSpouse-Example1"
+                    },
+                    {
+                      "reference": "Observation/DecedentAge-Example1"
+                    },
+                    {
+                      "reference": "Observation/BirthRecordIdentifier-Example1"
+                    },
+                    {
+                      "reference": "Observation/DecedentEducationLevel-Example1"
+                    },
+                    {
+                      "reference": "Observation/DecedentMilitaryService-Example1"
+                    },
+                    {
+                      "reference": "Observation/DecedentUsualWork-Example1"
+                    },
+                    {
+                      "reference": "Observation/InputRaceAndEthnicity-Example1"
+                    },
+                    {
+                      "reference": "Observation/EmergingIssues-Example1"
+                    }
+                  ]
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-document-section-cs",
+                        "code": "DeathInvestigation"
+                      }
+                    ]
+                  },
+                  "entry": [
+                    {
+                      "reference": "Observation/ExaminerContacted-Example1"
+                    },
+                    {
+                      "reference": "Observation/DecedentPregnancyStatus-Example1"
+                    },
+                    {
+                      "reference": "Observation/TobaccoUseContributedToDeath-Example1"
+                    },
+                    {
+                      "reference": "Observation/AutopsyPerformedIndicator-Example1"
+                    },
+                    {
+                      "reference": "Location/DeathLocation-Example1"
+                    },
+                    {
+                      "reference": "Location/InjuryLocation-Example1"
+                    },
+                    {
+                      "reference": "Observation/InjuryIncident-Example1"
+                    },
+                    {
+                      "reference": "Observation/DeathDate-Example1"
+                    },
+                    {
+                      "reference": "Observation/SurgeryDate-Example1"
+                    }
+                  ]
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-document-section-cs",
+                        "code": "DeathCertification"
+                      }
+                    ]
+                  },
+                  "entry": [
+                    {
+                      "reference": "Practitioner/Certifier-Example1"
+                    },
+                    {
+                      "reference": "Procedure/DeathCertification-Example1"
+                    },
+                    {
+                      "reference": "Observation/MannerOfDeath-Example1"
+                    },
+                    {
+                      "reference": "Observation/CauseOfDeathPart1-Example1"
+                    },
+                    {
+                      "reference": "Observation/CauseOfDeathPart1-Example2"
+                    },
+                    {
+                      "reference": "Observation/CauseOfDeathPart2-Example1"
+                    }
+                  ]
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-document-section-cs",
+                        "code": "DecedentDisposition"
+                      }
+                    ]
+                  },
+                  "entry": [
+                    {
+                      "reference": "Location/DispositionLocation-Example1"
+                    },
+                    {
+                      "reference": "Organization/FuneralHome-Example1"
+                    },
+                    {
+                      "reference": "Observation/DecedentDispositionMethod-Example1"
+                    },
+                    {
+                      "reference": "Practitioner/Mortician-Example1"
+                    }
+                  ]
+                }
+              ],
+              "status": "final",
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "date": "2020-11-15T16:39:54-05:00",
+              "author": [
+                {
+                  "reference": "Practitioner/Certifier-Example1"
+                }
+              ],
+              "title": "Death Certificate"
+            },
+            "fullUrl": "http://www.example.org/fhir/Bundle/DeathCertificate-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Patient",
+              "id": "Decedent-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent"
+                ]
+              },
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/SpouseAlive",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "code": "Y",
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/NVSS-SexAtDeath",
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "code": "unknown",
+                        "system": "http://hl7.org/fhir/administrative-gender",
+                        "display": "Unknown"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/patient-birthPlace",
+                  "valueAddress": {
+                    "city": "Roanoke",
+                    "state": "VA",
+                    "country": "US"
+                  }
+                }
+              ],
+              "address": [
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/WithinCityLimitsIndicator",
+                      "valueCoding": {
+                        "code": "Y",
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                        "display": "Yes"
+                      }
+                    },
+                    {
+                      "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/StreetName",
+                      "valueString": "Lockwood"
+                    }
+                  ],
+                  "line": [
+                    "5590 Lockwood Drive"
+                  ],
+                  "city": "Danville",
+                  "_city": {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/CityCode",
+                        "valuePositiveInt": 1234
+                      }
+                    ]
+                  },
+                  "state": "VA",
+                  "district": "Fairfax",
+                  "_district": {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/DistrictCode",
+                        "valuePositiveInt": 321
+                      }
+                    ]
+                  },
+                  "country": "US"
+                }
+              ],
+              "maritalStatus": {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/BypassEditFlag",
+                    "valueCodeableConcept": {
+                      "coding": [
+                        {
+                          "code": "0",
+                          "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-bypass-edit-flag-cs",
+                          "display": "Edit Passed"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "coding": [
+                  {
+                    "code": "S",
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus",
+                    "display": "Never Married"
+                  }
+                ]
+              },
+              "identifier": [
+                {
+                  "type": {
+                    "coding": [
+                      {
+                        "code": "SB",
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                        "display": "Social Beneficiary Identifier"
+                      }
+                    ]
+                  },
+                  "system": "http://hl7.org/fhir/sid/us-ssn",
+                  "value": "987654321"
+                }
+              ],
+              "name": [
+                {
+                  "use": "official",
+                  "family": "Patel",
+                  "given": [
+                    "Madelyn"
+                  ]
+                }
+              ],
+              "gender": "female",
+              "contact": [
+                {
+                  "name": {
+                    "text": "Joe Smith"
+                  },
+                  "relationship": [
+                    {
+                      "text": "Friend of family"
+                    }
+                  ]
+                }
+              ],
+              "_birthDate": {
+                "extension": [
+                  {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Day",
+                        "valueUnsignedInt": 10
+                      },
+                      {
+                        "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Year",
+                        "valueUnsignedInt": 2004
+                      },
+                      {
+                        "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Month",
+                        "valueUnsignedInt": 11
+                      }
+                    ],
+                    "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/PartialDate"
+                  }
+                ]
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Patient/Decedent-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "RelatedPerson",
+              "id": "DecedentFather-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-father"
+                ]
+              },
+              "relationship": [
+                {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                      "code": "FTH"
+                    }
+                  ]
+                }
+              ],
+              "patient": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "name": [
+                {
+                  "text": "Decedent Dad",
+                  "use": "official",
+                  "given": [
+                    "John"
+                  ],
+                  "family": "Smith",
+                  "suffix": [
+                    "Sr"
+                  ]
+                }
+              ]
+            },
+            "fullUrl": "http://www.example.org/fhir/RelatedPerson/DecedentFather-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "RelatedPerson",
+              "id": "DecedentMother-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-mother"
+                ]
+              },
+              "relationship": [
+                {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                      "code": "MTH"
+                    }
+                  ]
+                }
+              ],
+              "patient": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "name": [
+                {
+                  "text": "Decedent Mom",
+                  "use": "maiden",
+                  "given": [
+                    "Jane"
+                  ],
+                  "family": "Suzette"
+                }
+              ]
+            },
+            "fullUrl": "http://www.example.org/fhir/RelatedPerson/DecedentMother-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "RelatedPerson",
+              "id": "DecedentSpouse-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-spouse"
+                ]
+              },
+              "relationship": [
+                {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                      "code": "SPS"
+                    }
+                  ]
+                }
+              ],
+              "patient": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "name": [
+                {
+                  "text": "Decedent Spouse",
+                  "use": "maiden",
+                  "given": [
+                    "Samuel"
+                  ],
+                  "family": "Gazette",
+                  "suffix": [
+                    "III"
+                  ]
+                }
+              ]
+            },
+            "fullUrl": "http://www.example.org/fhir/RelatedPerson/DecedentSpouse-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "DecedentAge-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-age"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "39016-1"
+                  }
+                ]
+              },
+              "valueQuantity": {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/BypassEditFlag",
+                    "valueCodeableConcept": {
+                      "coding": [
+                        {
+                          "code": "0",
+                          "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-bypass-edit-flag-cs",
+                          "display": "Edit Passed"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "value": 42,
+                "unit": "a"
+              },
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/DecedentAge-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "InputRaceAndEthnicity-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-input-race-and-ethnicity"
+                ]
+              },
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-observations-cs",
+                    "code": "inputraceandethnicity"
+                  }
+                ]
+              },
+              "component": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "White"
+                      }
+                    ]
+                  },
+                  "valueBoolean": true
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "BlackOrAfricanAmerican"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "AmericanIndianOrAlaskanNative"
+                      }
+                    ]
+                  },
+                  "valueBoolean": true
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "AsianIndian"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "Chinese"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "Filipino"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "Japanese"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "Korean"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "Vietnamese"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "OtherAsian"
+                      }
+                    ]
+                  },
+                  "valueBoolean": true
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "NativeHawaiian"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "GuamanianOrChamorro"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "Samoan"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "OtherPacificIslander"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "OtherRace"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "FirstOtherAsianLiteral"
+                      }
+                    ]
+                  },
+                  "valueString": "Malaysian"
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "FirstAmericanIndianOrAlaskanNativeLiteral"
+                      }
+                    ]
+                  },
+                  "valueString": "Arikara"
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "HispanicMexican"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "code": "Y",
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                        "display": "Yes"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "HispanicCuban"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "code": "Y",
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                        "display": "No"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "HispanicPuertoRican"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "code": "Y",
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                        "display": "Yes"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "HispanicOther"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "code": "N",
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                        "display": "No"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "status": "final",
+              "subject": {
+                "display": "NCHS generated"
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/InputRaceAndEthnicity-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "BirthRecordIdentifier-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-birth-record-identifier"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                    "code": "BR",
+                    "display": "Birth registry number"
+                  }
+                ]
+              },
+              "component": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://loinc.org",
+                        "code": "21842-0"
+                      }
+                    ]
+                  },
+                  "valueString": "YC"
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://loinc.org",
+                        "code": "80904-6"
+                      }
+                    ]
+                  },
+                  "valueDateTime": "1961"
+                }
+              ],
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "valueString": "717171"
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/BirthRecordIdentifier-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "DecedentEducationLevel-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-education-level"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "80913-7"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "code": "SEC",
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-EducationLevel",
+                    "display": "Some secondary or high school education"
+                  }
+                ]
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/DecedentEducationLevel-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "DecedentMilitaryService-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-military-service"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "55280-2"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "code": "Y",
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                    "display": "Yes"
+                  }
+                ]
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/DecedentMilitaryService-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "DecedentUsualWork-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-usual-work"
+                ]
+              },
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "21843-8"
+                  }
+                ]
+              },
+              "component": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://loinc.org",
+                        "code": "21844-6",
+                        "display": "History of Usual industry"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "text": "State agency",
+                    "coding": [
+                      {
+                        "code": "UNK",
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                        "display": "unknown"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "status": "final",
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "valueCodeableConcept": {
+                "text": "secretary",
+                "coding": [
+                  {
+                    "code": "UNK",
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                    "display": "unknown"
+                  }
+                ]
+              },
+              "effectivePeriod": {
+                "start": "2001",
+                "end": "2005"
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/DecedentUsualWork-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "EmergingIssues-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-emerging-issues"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-observations-cs",
+                    "code": "emergingissues"
+                  }
+                ]
+              },
+              "component": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "EmergingIssue1_1"
+                      }
+                    ]
+                  },
+                  "valueString": "H"
+                }
+              ],
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/EmergingIssues-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "DecedentPregnancyStatus-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-pregnancy-status"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "69442-2"
+                  }
+                ]
+              },
+              "valueCodeableConcept": {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/BypassEditFlag",
+                    "valueCodeableConcept": {
+                      "coding": [
+                        {
+                          "code": "2",
+                          "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-bypass-edit-flag-cs",
+                          "display": "Edit Failed, Data Queried, but not Verified"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "coding": [
+                  {
+                    "code": "2",
+                    "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-pregnancy-status-cs",
+                    "display": "Pregnant at time of death"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/DecedentPregnancyStatus-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "TobaccoUseContributedToDeath-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-tobacco-use-contributed-to-death"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "69443-0",
+                    "display": "Did tobacco use contribute to death"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "code": "373066001",
+                    "system": "http://snomed.info/sct",
+                    "display": "Yes"
+                  }
+                ]
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/TobaccoUseContributedToDeath-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "DeathDate-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-date"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "81956-5"
+                  }
+                ]
+              },
+              "component": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://loinc.org",
+                        "code": "80616-6"
+                      }
+                    ]
+                  },
+                  "valueDateTime": "2020-11-13T16:39:40-05:00"
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://loinc.org",
+                        "code": "58332-8"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "code": "16983000",
+                        "system": "http://snomed.info/sct",
+                        "display": "Death in hospital"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "effectiveDateTime": "2020-11-12T16:39:40-05:00",
+              "performer": [
+                {
+                  "reference": "Practitioner/Certifier-Example1"
+                }
+              ],
+              "_valueDateTime": {
+                "extension": [
+                  {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Day",
+                        "valueUnsignedInt": 12
+                      },
+                      {
+                        "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Year",
+                        "valueUnsignedInt": 2020
+                      },
+                      {
+                        "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Month",
+                        "valueUnsignedInt": 11
+                      },
+                      {
+                        "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Date-Time",
+                        "_valueTime": {
+                          "extension": [
+                            {
+                              "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                              "valueCode": "unknown"
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/PartialDateTime"
+                  }
+                ]
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/DeathDate-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "SurgeryDate-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-surgery-date"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "80992-1"
+                  }
+                ]
+              },
+              "effectiveDateTime": "2019-11-12",
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/SurgeryDate-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "ExaminerContacted-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-examiner-contacted"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "74497-9"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "code": "Y",
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                    "display": "Yes"
+                  }
+                ]
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/ExaminerContacted-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "MannerOfDeath-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-manner-of-death"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "69449-7"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "code": "38605008",
+                    "system": "http://snomed.info/sct",
+                    "display": "Natural death"
+                  }
+                ]
+              },
+              "performer": [
+                {
+                  "reference": "Practitioner/Certifier-Example1"
+                }
+              ]
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/MannerOfDeath-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Location",
+              "id": "DeathLocation-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-location"
+                ]
+              },
+              "type": [
+                {
+                  "coding": [
+                    {
+                      "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
+                      "code": "death"
+                    }
+                  ]
+                }
+              ],
+              "name": "Pecan Grove Nursing Home",
+              "description": "nursing home",
+              "address": {
+                "city": "Albany",
+                "state": "NY",
+                "country": "US"
+              },
+              "position": {
+                "latitude": 38.889248,
+                "longitude": -77.050636
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Location/DeathLocation-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Location",
+              "id": "InjuryLocation-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-injury-location"
+                ]
+              },
+              "type": [
+                {
+                  "coding": [
+                    {
+                      "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
+                      "code": "injury"
+                    }
+                  ]
+                }
+              ],
+              "description": "5590 Lockwood Drive 20621 US",
+              "name": "Home",
+              "address": {
+                "text": "5590 Lockwood Drive 20621 US"
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Location/InjuryLocation-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "InjuryIncident-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-injury-incident"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "11374-6"
+                  }
+                ]
+              },
+              "component": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://loinc.org",
+                        "code": "69444-8"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "code": "N",
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                        "display": "No"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://loinc.org",
+                        "code": "69450-5"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "text": "Home"
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://loinc.org",
+                        "code": "69451-3"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "code": "OTH",
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                        "display": "Other"
+                      }
+                    ],
+                    "text": "Hoverboard Rider"
+                  }
+                }
+              ],
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "effectiveDateTime": "2019-11-02T13:00:00-05:00",
+              "valueCodeableConcept": {
+                "text": "drug toxicity"
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/InjuryIncident-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Practitioner",
+              "id": "Certifier-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-certifier"
+                ]
+              },
+              "name": [
+                {
+                  "use": "official",
+                  "family": "Black",
+                  "given": [
+                    "Jim"
+                  ]
+                }
+              ],
+              "address": [
+                {
+                  "line": [
+                    "44 South Street"
+                  ],
+                  "city": "Bird in Hand",
+                  "state": "PA",
+                  "postalCode": "17505",
+                  "country": "US"
+                }
+              ],
+              "identifier": [
+                {
+                  "system": "http://hl7.org/fhir/sid/us-npi",
+                  "value": "414444AB"
+                }
+              ],
+              "qualification": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "code": "434641000124105",
+                        "system": "http://snomed.info/sct"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "fullUrl": "http://www.example.org/fhir/Practitioner/Certifier-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Procedure",
+              "id": "DeathCertification-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-death-certification"
+                ]
+              },
+              "status": "completed",
+              "category": {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "103693007",
+                    "display": "Diagnostic procedure"
+                  }
+                ]
+              },
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "308646001",
+                    "display": "Death certification"
+                  }
+                ]
+              },
+              "identifier": [
+                {
+                  "value": "180"
+                }
+              ],
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "performedDateTime": "2020-11-14T16:39:40-05:00",
+              "performer": [
+                {
+                  "function": {
+                    "coding": [
+                      {
+                        "code": "OTH",
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                        "display": "Other"
+                      }
+                    ],
+                    "text": "Nurse Practitioner"
+                  },
+                  "actor": {
+                    "reference": "Practitioner/Certifier-Example1"
+                  }
+                }
+              ]
+            },
+            "fullUrl": "http://www.example.org/fhir/Procedure/DeathCertification-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "CauseOfDeathPart1-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1"
+                ]
+              },
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "69453-9"
+                  }
+                ]
+              },
+              "component": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "lineNumber"
+                      }
+                    ]
+                  },
+                  "valueInteger": 1
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://loinc.org",
+                        "code": "69440-6"
+                      }
+                    ]
+                  },
+                  "valueString": "4 hours"
+                }
+              ],
+              "valueCodeableConcept": {
+                "text": null
+              },
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "performer": [
+                {
+                  "reference": "Practitioner/Certifier-Example1"
+                }
+              ],
+              "status": "final"
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/CauseOfDeathPart1-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "CauseOfDeathPart1-Example2",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part1"
+                ]
+              },
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "69453-9"
+                  }
+                ]
+              },
+              "component": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs",
+                        "code": "lineNumber"
+                      }
+                    ]
+                  },
+                  "valueInteger": 2
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://loinc.org",
+                        "code": "69440-6"
+                      }
+                    ]
+                  },
+                  "valueString": "3 months"
+                }
+              ],
+              "valueCodeableConcept": {
+                "text": "Eclampsia"
+              },
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "performer": [
+                {
+                  "reference": "Practitioner/Certifier-Example1"
+                }
+              ],
+              "status": "final"
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/CauseOfDeathPart1-Example2"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "CauseOfDeathPart2-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-cause-of-death-part2"
+                ]
+              },
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "69441-4"
+                  }
+                ]
+              },
+              "valueCodeableConcept": {
+                "text": "hypertensive heart disease"
+              },
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "performer": [
+                {
+                  "reference": "Practitioner/Certifier-Example1"
+                }
+              ],
+              "status": "final"
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/CauseOfDeathPart2-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Location",
+              "id": "DispositionLocation-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-disposition-location"
+                ]
+              },
+              "type": [
+                {
+                  "coding": [
+                    {
+                      "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-location-type-cs",
+                      "code": "disposition"
+                    }
+                  ]
+                }
+              ],
+              "name": "Rosewood Cemetary",
+              "address": {
+                "line": [
+                  "303 Rosewood Ave"
+                ],
+                "city": "Danville",
+                "state": "VA",
+                "postalCode": "24541",
+                "country": "US"
+              },
+              "physicalType": {
+                "coding": [
+                  {
+                    "code": "si",
+                    "system": "http://terminology.hl7.org/CodeSystem/location-physical-type",
+                    "display": "Site"
+                  }
+                ]
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Location/DispositionLocation-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Organization",
+              "id": "FuneralHome-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-funeral-home"
+                ]
+              },
+              "type": [
+                {
+                  "coding": [
+                    {
+                      "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-organization-type-cs",
+                      "code": "funeralhome",
+                      "display": "Funeral Home"
+                    }
+                  ]
+                }
+              ],
+              "active": true,
+              "name": "Lancaster Funeral Home and Crematory",
+              "address": [
+                {
+                  "line": [
+                    "211 High Street"
+                  ],
+                  "city": "Lancaster",
+                  "state": "PA",
+                  "postalCode": "17573",
+                  "country": "US"
+                }
+              ]
+            },
+            "fullUrl": "http://www.example.org/fhir/Organization/FuneralHome-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "DecedentDispositionMethod-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-decedent-disposition-method"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "80905-3"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "performer": [
+                {
+                  "reference": "Practitioner/Mortician-Example1"
+                }
+              ],
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "code": "449971000124106",
+                    "system": "http://snomed.info/sct",
+                    "display": "Burial"
+                  }
+                ]
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/DecedentDispositionMethod-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "AutopsyPerformedIndicator-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vrdr/StructureDefinition/vrdr-autopsy-performed-indicator"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "85699-7"
+                  }
+                ]
+              },
+              "component": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://loinc.org",
+                        "code": "69436-4"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "code": "Y",
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                        "display": "Yes"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "subject": {
+                "reference": "Patient/Decedent-Example1"
+              },
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "code": "Y",
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                    "display": "Yes"
+                  }
+                ]
+              }
+            },
+            "fullUrl": "http://www.example.org/fhir/Observation/AutopsyPerformedIndicator-Example1"
+          },
+          {
+            "resource": {
+              "resourceType": "Practitioner",
+              "id": "Mortician-Example1",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+                ]
+              },
+              "identifier": [
+                {
+                  "system": "http://hl7.org/fhir/sid/us-npi",
+                  "value": "212222AB"
+                }
+              ],
+              "name": [
+                {
+                  "use": "official",
+                  "family": "Smith",
+                  "given": [
+                    "Ronald",
+                    "Q"
+                  ]
+                }
+              ]
+            },
+            "fullUrl": "http://www.example.org/fhir/Practitioner/Mortician-Example1"
+          }
+        ]
+      },
+      "fullUrl": "http://www.example.org/fhir/Bundle/DeathCertificateDocument-Example1"
+    }
+  ]
+}

--- a/messaging.tests/messaging.tests.csproj
+++ b/messaging.tests/messaging.tests.csproj
@@ -32,5 +32,7 @@
     <None Update="fixtures/json/ExtractionErrorMessage.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/FetalDeathRecordSubmissionMessage.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/DeathRecordSubmissionMessageV2_2.json" CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>  
+    <None Update="fixtures/json/DeathRecordSubmissionBlankString.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="fixtures/json/DeathRecordSubmissionNullValue.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 </Project>

--- a/messaging/Controllers/BundlesController.cs
+++ b/messaging/Controllers/BundlesController.cs
@@ -493,6 +493,8 @@ namespace messaging.Controllers
         {
             try
             {
+                // Parse the message strictly. Any issues (e.g. invalid FHIR) will be reported back up
+                // to the submitter via an ArgumentException.
                 Bundle bundle = CommonMessage.ParseGenericBundle(resource.ToString());
 
                 CommonMessage message;


### PR DESCRIPTION
This PR includes:
- A minor refactor on how submitted bundles are handled:
  - Bundles are initially parsed as generic JSON, just enough to tell if the bundle is a batch or message.
  - Batches are split up and handled on a per entry basis. Each entry is treated as a distinct message. `InsertBatchMessage` and `ParseIncomingMessageItem` have been adjusted to handle the raw resource instead of the previously permissively parsed bundle.
  - `ParseIncomingMessageItem` now does a strict parse on the message. If it's invalid FHIR, the issues are properly reported back to the submitter.
- Added tests for bundles with blank strings and null values.
- Updated launch.json to use net6.0 for debugging.