### PR TITLE
776 - Add eventYear param

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,18 +73,35 @@ which returns any message response that has not been retrieved yet
 
 #### Optional Test Receive Responses GET Parameters
 
-There are 3 optional parameters that can be included in a GET request to this endpoint. They are `_since`, `certificateNumber`, and `deathYear`
+There are 3 optional parameters that can be included in a GET request to this endpoint. These can be useful for seeing the message response history for a particular record and verifying you successfully retrieved all messages during your testing.
 
-`_since` is to retrieve all response messages since a given timestamp. It is useful for seeing ALL message responses created in a specific time window.  
+Providing any of these three search parameters may result in multiple pages of results. To make sure you retrieve all of the pages in the HTTP response, you will need to use pagination. See pagination section for details. Currently, these test parameters are only supported by the backup endpoint. If any of these parameters are included in a request, the results that are returned will not be marked as retrieved.
+
+##### `_since`
+
+`_since` will retrieve all response messages since a given timestamp. It is useful for seeing ALL message responses created in a specific time window.
+
+The timestamp should be in the following format: `yyyy-MM-ddTHH:mm:ss.fffffff`.
+
 ```
-GET https://localhost:5001/<jurisdiction-id>/Bundle?_since=yyyy-MM-ddTHH:mm:ss.fffffff
+GET https://localhost:5001/<jurisdiction-id>/Bundle?_since=1970-01-01T00:00:00.0000000
 ```
 
-`deathYear` and `certificateNumber` can be used together or seperately to retrieve all message responses for the given set of business ids. It is useful for seeing the message response history for a particular record and verifying you successfully retrieved all messages during your testing. Currently, these test parameters are only supported by the backup endpoint.
+##### `certificateNumber`
 
-Providing any of these three search parameters may result in multiple pages of results. To make sure you retrieve all of the pages in the HTTP response, you will need to use pagination. See pagination section for details.
+`certificateNumber` will retrieve all response messages that match the given number.
 
-If any of these parameters are included in a request, the results that are returned will not be marked as retrieved.
+```
+GET https://localhost:5001/<jurisdiction-id>/Bundle?certificateNumber=123456
+```
+
+##### `eventYear`
+
+`eventYear` will retrieve all response messages that match the given event year (e.g. for death records this is the death year).
+
+```
+GET https://localhost:5001/<jurisdiction-id>/Bundle?eventYear=2018
+```
 
 #### NCHS API GET Request message types
 The API supports GET requests to retrieve responses from NCHS, including:

--- a/messaging.tests/Integration/BundlesControllerTests.cs
+++ b/messaging.tests/Integration/BundlesControllerTests.cs
@@ -444,6 +444,78 @@ namespace messaging.tests
         }
 
         [Fact]
+        public async System.Threading.Tasks.Task QueryByDeathYearAndEventYear()
+        {
+            // Clear any messages in the database for a clean test
+            DatabaseHelper.ResetDatabase(_context);
+
+            // Create a new empty Death Record
+            DeathRecordSubmissionMessage drSub = new(new DeathRecord())
+            {
+                // Set missing required fields
+                MessageSource = "http://example.fhir.org",
+                CertNo = 123,
+                DeathYear = 2020,
+                JurisdictionId = "ND"
+            };
+
+            // Submit that Death Record
+            HttpResponseMessage drSubResp = await JsonResponseHelpers.PostJsonAsync(_client, "/" + drSub.JurisdictionId + "/Bundle/VRDR/VRDR_STU3_0", drSub.ToJson());
+            Assert.Equal(HttpStatusCode.NoContent, drSubResp.StatusCode);
+            await System.Threading.Tasks.Task.Delay(1000);
+
+            // Query Death Record by deathYear
+            HttpResponseMessage vrdrByDeathYear = await _client.GetAsync("/" + drSub.JurisdictionId + "/Bundle/VRDR/VRDR_STU3_0?deathYear=" + drSub.DeathYear);
+            Bundle vrdrDeathYearBundle = await JsonResponseHelpers.ParseBundleAsync(vrdrByDeathYear);
+            Assert.Single(vrdrDeathYearBundle.Entry);
+
+            // Query Death Record by eventYear
+            HttpResponseMessage vrdrByEventYear = await _client.GetAsync("/" + drSub.JurisdictionId + "/Bundle/VRDR/VRDR_STU3_0?eventYear=" + drSub.DeathYear);
+            Bundle vrdrByEventYearBundle = await JsonResponseHelpers.ParseBundleAsync(vrdrByEventYear);
+            Assert.Single(vrdrByEventYearBundle.Entry);
+
+            // Create a new empty Fetal Death Record
+            FetalDeathRecordSubmissionMessage fdrSub = new(new FetalDeathRecord())
+            {
+                // Set missing required fields
+                MessageSource = "http://example.fhir.org",
+                CertNo = 123,
+                EventYear = 2020,
+                JurisdictionId = "ND"
+            };
+
+            // Submit that Fetal Death Record
+            HttpResponseMessage fdrSubResp = await JsonResponseHelpers.PostJsonAsync(_client, "/" + fdrSub.JurisdictionId + "/Bundle/BFDR-FETALDEATH/BFDR_STU2_0", fdrSub.ToJson());
+            Assert.Equal(HttpStatusCode.NoContent, fdrSubResp.StatusCode);
+            await System.Threading.Tasks.Task.Delay(1000);
+
+            // Query Fetal Death Record by eventYear
+            HttpResponseMessage fdrByEventYear = await _client.GetAsync("/" + fdrSub.JurisdictionId + "/Bundle/BFDR-FETALDEATH/BFDR_STU2_0?eventYear=" + fdrSub.EventYear);
+            Bundle fdrByEventYearBundle = await JsonResponseHelpers.ParseBundleAsync(fdrByEventYear);
+            Assert.Single(fdrByEventYearBundle.Entry);
+
+            // Create a new empty Birth Record
+            BirthRecordSubmissionMessage brSub = new(new BirthRecord())
+            {
+                // Set missing required fields
+                MessageSource = "http://example.fhir.org",
+                CertNo = 123,
+                EventYear = 2020,
+                JurisdictionId = "ND"
+            };
+
+            // Submit that Birth Record
+            HttpResponseMessage brSubResp = await JsonResponseHelpers.PostJsonAsync(_client, "/" + brSub.JurisdictionId + "/Bundle/BFDR-BIRTH/BFDR_STU2_0", brSub.ToJson());
+            Assert.Equal(HttpStatusCode.NoContent, brSubResp.StatusCode);
+            await System.Threading.Tasks.Task.Delay(1000);
+
+            // Query Birth Record by eventYear
+            HttpResponseMessage brByEventYear = await _client.GetAsync("/" + brSub.JurisdictionId + "/Bundle/BFDR-BIRTH/BFDR_STU2_0?eventYear=" + brSub.EventYear);
+            Bundle brByEventYearBundle = await JsonResponseHelpers.ParseBundleAsync(brByEventYear);
+            Assert.Single(brByEventYearBundle.Entry);
+        }
+
+        [Fact]
         public async System.Threading.Tasks.Task UnparsableMessagesCauseAnError() {
             // Clear any messages in the database for a clean test
             DatabaseHelper.ResetDatabase(_context);

--- a/messaging/Controllers/BundlesController.cs
+++ b/messaging/Controllers/BundlesController.cs
@@ -50,9 +50,14 @@ namespace messaging.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public async Task<ActionResult<Bundle>> GetOutgoingMessageItems(string jurisdictionId, string vitalType, string igVersion, int _count, string certificateNumber, string deathYear, DateTime _since = default(DateTime), int page = 1)
+        public async Task<ActionResult<Bundle>> GetOutgoingMessageItems(string jurisdictionId, string vitalType, string igVersion, int _count, string certificateNumber, string eventYear, string deathYear, DateTime _since = default(DateTime), int page = 1)
         {
-            bool additionalParamsProvided = !(_since == default(DateTime) && certificateNumber == null && deathYear == null);
+            if (eventYear == null && deathYear != null)
+            {
+                eventYear = deathYear; // Only if eventYear wasn't specified
+            }
+
+            bool additionalParamsProvided = !(_since == default(DateTime) && certificateNumber == null && eventYear == null);
 
             if (_count == 0)
             {
@@ -97,10 +102,10 @@ namespace messaging.Controllers
             if (!additionalParamsProvided && page > 1)
             {
                 _logger.LogError("Rejecting request with a page number but no _since parameter.");
-                return BadRequest("Pagination does not support specifying a page without either a _since, certificateNumber, or deathYear parameter");
+                return BadRequest("Pagination does not support specifying a page without either a _since, certificateNumber, or eventYear/deathYear parameter");
             }
-            _logger.LogDebug($"Provided params: {certificateNumber}, {deathYear}, {_since}");
-            
+            _logger.LogDebug($"Provided params: {certificateNumber}, {eventYear}, {_since}");
+
             RouteValueDictionary searchParamValues = new()
             {
                 { "jurisdictionId", jurisdictionId },
@@ -111,8 +116,10 @@ namespace messaging.Controllers
                 certificateNumber = certificateNumber.PadLeft(6, '0');
                 searchParamValues.Add("certificateNumber", certificateNumber);
             }
-            if (deathYear != null) {
-                searchParamValues.Add("deathYear", deathYear);
+
+            if (eventYear != null)
+            {
+                searchParamValues.Add("eventYear", eventYear);
             }
 
             // Query for outgoing messages of the requested type by jurisdiction ID. Filter by IG version. Optionally filter by certificate number and death year if those parameters are provided.
@@ -120,7 +127,7 @@ namespace messaging.Controllers
                     && (String.IsNullOrEmpty(recordType) || message.EventType.Equals(recordType))
                     && igVersion.Equals(message.IGVersion)
                     && (certificateNumber == null || message.CertificateNumber.Equals(certificateNumber))
-                    && (deathYear == null || message.EventYear == int.Parse(deathYear)));
+                    && (eventYear == null || message.EventYear == int.Parse(eventYear)));
 
             try
             {


### PR DESCRIPTION
Adds an `eventYear` parameter for the GetOutgoingMessageItems endpoint.

This is built off of https://github.com/nightingaleproject/Reference-NCHS-API/pull/113, which should be merged before this.