### PR TITLE
docs: add contribution guide and code of conduct

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## I. Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance,
+race, religion, or sexual identity and orientation.
+
+## II. Standards of Behavior
+
+Examples of behavior that contributes to creating a positive environment include
+but may not be limited to:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include but may not be limited
+to:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## III. Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and will take corrective action in response to any violations of the
+Standards of Behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, or to temporarily or permanently ban any
+contributor for other behaviors that Reference NVSS API deem inappropriate,
+threatening, offensive, or harmful.
+
+## IV. Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## V. Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at nvssmodernization@cdc.gov. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team shall
+maintain the confidentiality of the reporter of an incident. Further details of
+specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## VI. Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 1.4,
+available at
+<https://www.contributor-covenant.org/version/1/4/code-of-conduct.html>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,122 @@
+# Contributing
+
+Thank you for your interest in contributing to the open source Reference NVSS
+API project! We welcome all friendly contributions, including:
+
+- Bug reports
+- Comments and suggestions
+- Feature requests
+- Bug fixes
+- Feature implementations and enhancements
+- Documentation updates and additions
+
+To ensure a welcoming environment, we follow the
+[Contributor Covenant Code of Conduct](CODE-OF-CONDUCT.md) and expect
+contributors to do the same.
+
+Before making a contribution, please familiarize yourself with this document and
+the project [README](README.md).
+
+## Issues
+
+We use GitHub issues to track bug reports, comments, suggestions, questions, and
+feature requests.
+
+Before submitting a new issue, please check to make sure a similar issue isn't
+already open. If one is, contribute to that issue thread with your feedback.
+
+When submitting a bug report, please try to provide as much detail as possible.
+This may include:
+
+- Steps to reproduce the problem
+- Screenshots demonstrating the problem
+- The full text of error messages
+- Relevant outputs
+- Any other information you deem relevant
+
+Please note that the GitHub issue tracker is _public_; any issues you submit are
+immediately visible to everyone. For this reason, do _not_ submit any
+information that may be considered sensitive.
+
+## Code Contributions
+
+If you are planning to work on a reported bug, suggestion, or feature request,
+please comment on the relevant issue to indicate your intent to work on it. If
+there is no associated issue, please submit a new issue describing the feature
+you plan to implement or the bug you plan to fix. This reduces the likelihood of
+duplicated effort and also provides the maintainers an opportunity to ask
+questions, provide hints, or indicate any concerns _before_ you invest your
+time.
+
+### Coding Practices
+
+Code that is contributed to this project should follow these practices:
+
+- Make changes in a personal
+  [fork](https://help.github.com/articles/fork-a-repo/) of this repository
+- Use descriptive commit messages, referencing relevant issues as appropriate
+  (e.g., "Fixes \#555: Update component to...")
+- Follow the styles and conventions as enforced by the lint configurations and
+  as evidenced by the existing code
+- Prefer self-explanatory code as much as possible, but provide helpful comments
+  for complex expressions and code blocks
+- Ensure any user-facing components are accessible (i.e., compliant with
+  [Section 508](https://www.section508.gov/))
+- Include unit tests for any new or changed functionality
+- Update documentation to reflect any user-facing changes
+
+### Before Submitting a Pull Request
+
+Before submitting a Pull Request for a code contribution:
+
+- [Rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) on master if
+  your code is out of synch with master
+  - If you need help with this, submit your Pull Request without rebasing and
+    indicate you need help
+- Build the code (if applicable) and ensure there are no new warnings or errors
+- Run the tests and ensure that all tests pass
+- Run the linter and ensure that there are no linter warnings or errors
+
+For details on how to build, test, and lint, see the project README file.
+
+### Submitting a Pull Request
+
+Pull requests should include a summary of the work, as well as any specific
+guidance regarding how to test or invoke the code.
+
+When project maintainers review the pull request, they will:
+
+- Verify the contribution is compatible with the project's goals and mission
+- Run the project's unit tests and linters to ensure there are no violations
+- Deploy the code locally to ensure it works as expected
+- Review all code changes in detail, looking for:
+  - Potential bugs, regressions, security issues, or unintended consequences
+  - Edge cases that may not be properly handled
+  - Application of generally accepted best practices
+  - Adequate unit tests and documentation
+
+### If the Pull Request Passes Review
+
+Congratulations! Your code will be merged by a maintainer into the project's
+master branch!
+
+### If the Pull Request Does Not Pass Review
+
+If the review process uncovers any issues or concerns, a maintainer will
+communicate them via a Pull Request comment. In most cases, the maintainer will
+also suggest changes that can be made to address those concerns and eventually
+have the Pull Request accepted. If this happens:
+
+- Address any noted issues or concerns
+- Rebase (if necessary) and push your code again (may require a force push if
+  you rebased)
+- Comment on the Pull Request indicating it is ready for another review
+
+## Apache 2.0
+
+All contributions to this project will be released under the
+[Apache 2.0 license](http://www.apache.org/licenses/LICENSE-2.0). By submitting
+a pull request, you are agreeing to comply with this license. As indicated by
+the license, you are also attesting that you are the copyright owner, or an
+individual or Legal Entity authorized to submit the contribution on behalf of
+the copyright owner.

--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ This repository also provides a Status UI dashboard for analyzing messages recie
 
 # API Developer Documentation
 
-This section documents information useful for developers of the API itself and is not relevant to users of the API or developers of systems that use the API.
+This section documents information useful for developers of the API itself and is not relevant to users of the API or developers of systems that use the API. Please also refer to the [contribution guide](CONTRIBUTING.md) and [code of conduct](CODE-OF-CONDUCT.md).
 
 ## Version Updates
 


### PR DESCRIPTION
Add links to contribution guide and code of conduct in the API Developer Documentation section of the README.

Addresses Jira issue 491.